### PR TITLE
fix: pass WATCHTOWER_TOKEN to meticai container for authenticated probes

### DIFF
--- a/apps/server/api/routes/system.py
+++ b/apps/server/api/routes/system.py
@@ -61,6 +61,9 @@ WATCHTOWER_TRIGGERABLE_STATUS_CODES = {200, 204}
 async def _probe_watchtower_api(method: str = "get") -> dict:
     """Probe known Watchtower API endpoints.
 
+    Sends an Authorization header when the ``WATCHTOWER_TOKEN`` env-var is
+    set so that the probe (and trigger) succeeds on token-protected instances.
+
     Returns:
         {
             "reachable": bool,
@@ -72,15 +75,20 @@ async def _probe_watchtower_api(method: str = "get") -> dict:
     """
     import httpx
 
+    token = os.environ.get("WATCHTOWER_TOKEN", "").strip()
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
     errors: list[str] = []
 
     async def _probe_one(client: httpx.AsyncClient, endpoint: str) -> dict:
         timeout = 3.0 if method == "post" else 2.0
         try:
             if method == "post":
-                response = await client.post(endpoint, timeout=timeout)
+                response = await client.post(endpoint, timeout=timeout, headers=headers)
             else:
-                response = await client.get(endpoint, timeout=timeout)
+                response = await client.get(endpoint, timeout=timeout, headers=headers)
 
             status_code = response.status_code
             return {

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -1428,6 +1428,83 @@ class TestUpdateMethodEndpoint:
         assert data["can_trigger_update"] is False
         assert "address already in use" in data["watchtower_error"]
 
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test_api_key", "WATCHTOWER_TOKEN": "test-token-123"})
+    @patch('httpx.AsyncClient')
+    def test_update_method_sends_auth_header_when_token_set(self, mock_client_cls, client):
+        """Sends Authorization header when WATCHTOWER_TOKEN env var is set."""
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        response = client.get("/api/update-method")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["method"] == "watchtower"
+        assert data["watchtower_running"] is True
+        assert data["can_trigger_update"] is True
+
+        # Verify the auth header was sent
+        call_kwargs = mock_client.get.call_args
+        assert call_kwargs is not None
+        assert call_kwargs.kwargs.get("headers", {}).get("Authorization") == "Bearer test-token-123"
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test_api_key"}, clear=False)
+    @patch('httpx.AsyncClient')
+    def test_update_method_no_auth_header_without_token(self, mock_client_cls, client):
+        """Does not send Authorization header when WATCHTOWER_TOKEN is unset."""
+        # Ensure WATCHTOWER_TOKEN is not in environment
+        import os as _os
+        _os.environ.pop("WATCHTOWER_TOKEN", None)
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 401
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        response = client.get("/api/update-method")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["method"] == "watchtower"
+        assert data["watchtower_running"] is True
+        assert data["can_trigger_update"] is False
+
+        # Verify no auth header was sent
+        call_kwargs = mock_client.get.call_args
+        assert call_kwargs is not None
+        assert call_kwargs.kwargs.get("headers", {}) == {}
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test_api_key", "WATCHTOWER_TOKEN": "trigger-token"})
+    @patch('httpx.AsyncClient')
+    def test_trigger_update_sends_auth_header(self, mock_client_cls, client):
+        """Trigger-update POST sends Authorization header when token is set."""
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        response = client.post("/api/trigger-update")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+
+        # Verify the auth header was sent on POST
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs is not None
+        assert call_kwargs.kwargs.get("headers", {}).get("Authorization") == "Bearer trigger-token"
+
 
 class TestHistoryAPI:
     """Tests for the profile history API endpoints."""

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,6 +19,8 @@ services:
       # Legacy v1.x data mount — enables automatic migration on first boot.
       # Only loaded during migration (no -f flags); not present in fresh v2 installs.
       - ./data:/legacy-data:ro
+    environment:
+      - WATCHTOWER_TOKEN=${WATCHTOWER_TOKEN:-meticai-migration-token}
 
   watchtower:
     image: containrrr/watchtower:latest

--- a/docker-compose.watchtower.yml
+++ b/docker-compose.watchtower.yml
@@ -37,3 +37,7 @@ services:
         max-size: "5m"
         max-file: "2"
     command: --http-api-metrics --http-api-periodic-polls --interval 21600
+
+  meticai:
+    environment:
+      - WATCHTOWER_TOKEN=${WATCHTOWER_TOKEN:-}


### PR DESCRIPTION
## Problem

The watchtower API probe (`_probe_watchtower_api`) always received HTTP 401 from token-protected Watchtower instances because the `WATCHTOWER_TOKEN` environment variable was only available inside the `watchtower` container — not in the `meticai` container where the probe runs.

This caused `can_trigger_update: false` even when Watchtower was running and correctly configured, meaning the Settings UI showed a yellow dot instead of green and on-demand update triggers failed.

## Changes

### Docker Compose
- **`docker-compose.watchtower.yml`**: Pass `WATCHTOWER_TOKEN` to the `meticai` service so the probe can authenticate
- **`docker-compose.override.yml`**: Same for the v1.x migration path

### Backend
- **`_probe_watchtower_api()`**: Read `WATCHTOWER_TOKEN` from env and send `Authorization: Bearer <token>` header on all probe requests (both GET and POST)

### Tests
- Add 3 new tests verifying:
  - Auth header is sent when `WATCHTOWER_TOKEN` is set (GET probe)
  - No auth header when token is unset (GET probe)
  - Auth header is sent on trigger-update POST

All 578 tests pass.