### PR TITLE
feat: mobile home screen above-the-fold layout (#287)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -838,7 +838,7 @@ function App() {
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={motionTransition ?? { duration: 0.5, ease: "easeOut" }}
-          className={isHome ? "text-center mb-10" : "text-center mb-6"}
+          className={isHome ? "text-center mb-6 lg:mb-10" : "text-center mb-6"}
         >
           <div className="flex items-center justify-center gap-3 mb-1 relative">
             <div 
@@ -849,8 +849,8 @@ function App() {
               onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleTitleClick() } }}
               aria-label={t('a11y.goHome')}
             >
-              <MeticAILogo size={isHome ? 48 : 28} variant={isDark ? 'white' : 'default'} />
-              <h1 className={`font-bold tracking-tight transition-all duration-300 ${isHome ? 'text-5xl' : 'text-2xl'}`}>
+              <MeticAILogo size={isHome ? (isMobile ? 36 : 48) : 28} variant={isDark ? 'white' : 'default'} />
+              <h1 className={`font-bold tracking-tight transition-all duration-300 ${isHome ? 'text-4xl lg:text-5xl' : 'text-2xl'}`}>
                 Metic<span className="gold-text">AI</span>
               </h1>
             </div>
@@ -928,6 +928,14 @@ function App() {
                   onSettings={() => setViewState('settings')}
                   aiConfigured={aiAvailable}
                   hideAiWhenUnavailable={hideAiWhenUnavailable}
+                  controlCenter={
+                    showControlCenter && isMobile ? (
+                      <ControlCenter
+                        machineState={machineState}
+                        onOpenLiveView={() => setViewState('live-shot')}
+                      />
+                    ) : undefined
+                  }
                   lastShotBanner={
                     mqttEnabled ? (
                       <LastShotBanner
@@ -1147,15 +1155,7 @@ function App() {
             </AnimatePresence>
             </Suspense>
 
-            {/* Mobile Control Center — below the main card, StartView only */}
-            {showControlCenter && isMobile && viewState === 'start' && (
-              <div className="mt-4">
-                <ControlCenter
-                  machineState={machineState}
-                  onOpenLiveView={() => setViewState('live-shot')}
-                />
-              </div>
-            )}
+            {/* Mobile Control Center — now rendered inside StartView */}
           </main>
 
           {/* ── Right column — desktop Control Center ─── */}

--- a/apps/web/src/views/StartView.tsx
+++ b/apps/web/src/views/StartView.tsx
@@ -56,6 +56,7 @@ interface StartViewProps {
   onSettings: () => void
   aiConfigured?: boolean
   hideAiWhenUnavailable?: boolean
+  controlCenter?: React.ReactNode
   lastShotBanner?: React.ReactNode
 }
 
@@ -71,6 +72,7 @@ export function StartView({
   onSettings,
   aiConfigured = true,
   hideAiWhenUnavailable = false,
+  controlCenter,
   lastShotBanner,
 }: StartViewProps) {
   const { t } = useTranslation()
@@ -110,7 +112,7 @@ export function StartView({
       exit="hidden"
       transition={gentleSpring}
     >
-      <Card className="p-6 space-y-6">
+      <Card className="p-6 space-y-4 lg:space-y-6">
         <div className="text-center space-y-2">
           <h2 className="text-xl font-bold tracking-tight text-foreground">{greeting}</h2>
           <p className="text-sm text-muted-foreground">
@@ -120,21 +122,24 @@ export function StartView({
           </p>
         </div>
 
+        {/* Control Center — machine status (mobile only, passed from App) */}
+        {controlCenter}
+
         {/* Last-shot analysis prompt */}
         <AnimatePresence>
           {lastShotBanner}
         </AnimatePresence>
 
-        <div className="space-y-3">
-          {/* Dark Brew — deep brown, gold text */}
+        <div className="space-y-2 lg:space-y-3">
+          {/* Generate New — primary action, always full width */}
           {(!hideAiWhenUnavailable || aiConfigured) && (
             <Button
               onClick={onGenerateNew}
               disabled={!aiConfigured}
               variant="dark-brew"
-              className="w-full h-14 text-base"
+              className="w-full h-12 lg:h-14 text-sm lg:text-base"
             >
-              <Plus size={20} className="mr-2" weight="bold" />
+              <Plus size={20} className="mr-1.5 lg:mr-2" weight="bold" />
               {t('navigation.generateNewProfile')}
             </Button>
           )}
@@ -144,63 +149,64 @@ export function StartView({
               {t('navigation.aiUnavailable')}
             </p>
           )}
-          
-          {/* Style 2: Dark Brew — deep brown, gold text */}
-          <Button
-            onClick={onProfileCatalogue ?? onViewHistory}
-            variant="dark-brew"
-            className="w-full h-14 text-base"
-          >
-            <Coffee size={20} className="mr-2" weight="fill" />
-            {t('navigation.profileCatalogue')}
-          </Button>
-          
-          {/* Dark Brew — deep brown, gold text */}
-          <Button
-            onClick={onRunShot}
-            variant="dark-brew"
-            className="w-full h-14 text-base"
-          >
-            <Play size={20} className="mr-2" weight="fill" />
-            {t('navigation.runSchedule')}
-          </Button>
 
-          <Button
-            onClick={onDialIn}
-            variant="dark-brew"
-            className="w-full h-14 text-base"
-          >
-            <Crosshair size={20} className="mr-2" weight="bold" />
-            {t('dialIn.title')}
-          </Button>
+          {/* Core actions — 2-col grid on mobile, stacked on desktop */}
+          <div className="grid grid-cols-2 gap-2 lg:grid-cols-1 lg:gap-3">
+            <Button
+              onClick={onProfileCatalogue ?? onViewHistory}
+              variant="dark-brew"
+              className="w-full h-12 lg:h-14 text-sm lg:text-base whitespace-normal lg:whitespace-nowrap"
+            >
+              <Coffee size={20} className="mr-1.5 lg:mr-2 shrink-0" weight="fill" />
+              {t('navigation.profileCatalogue')}
+            </Button>
 
-          <Button
-            onClick={onPourOver}
-            variant="dark-brew"
-            className="w-full h-14 text-base"
-          >
-            <Drop size={20} className="mr-2" weight="fill" />
-            {t('pourOver.title')}
-          </Button>
+            <Button
+              onClick={onRunShot}
+              variant="dark-brew"
+              className="w-full h-12 lg:h-14 text-sm lg:text-base whitespace-normal lg:whitespace-nowrap"
+            >
+              <Play size={20} className="mr-1.5 lg:mr-2 shrink-0" weight="fill" />
+              {t('navigation.runSchedule')}
+            </Button>
 
-          <Button
-            onClick={onShotAnalysis}
-            variant="dark-brew"
-            className="w-full h-14 text-base"
-          >
-            <ChartLine size={20} className="mr-2" weight="bold" />
-            {t('navigation.shotAnalysis')}
-          </Button>
-          
-          {/* Style 4: Ember — warm orange inner glow + border */}
-          <Button
-            onClick={onSettings}
-            variant="ember"
-            className="w-full h-14 text-base"
-          >
-            <Gear size={20} className="mr-2" weight="duotone" />
-            {t('navigation.settings')}
-          </Button>
+            <Button
+              onClick={onDialIn}
+              variant="dark-brew"
+              className="w-full h-12 lg:h-14 text-sm lg:text-base whitespace-normal lg:whitespace-nowrap"
+            >
+              <Crosshair size={20} className="mr-1.5 lg:mr-2 shrink-0" weight="bold" />
+              {t('dialIn.title')}
+            </Button>
+
+            <Button
+              onClick={onPourOver}
+              variant="dark-brew"
+              className="w-full h-12 lg:h-14 text-sm lg:text-base whitespace-normal lg:whitespace-nowrap"
+            >
+              <Drop size={20} className="mr-1.5 lg:mr-2 shrink-0" weight="fill" />
+              {t('pourOver.title')}
+            </Button>
+
+            <Button
+              onClick={onShotAnalysis}
+              variant="dark-brew"
+              className="w-full h-12 lg:h-14 text-sm lg:text-base whitespace-normal lg:whitespace-nowrap"
+            >
+              <ChartLine size={20} className="mr-1.5 lg:mr-2 shrink-0" weight="bold" />
+              {t('navigation.shotAnalysis')}
+            </Button>
+
+            {/* Settings — ember accent, completes the 2×3 grid */}
+            <Button
+              onClick={onSettings}
+              variant="ember"
+              className="w-full h-12 lg:h-14 text-sm lg:text-base whitespace-normal lg:whitespace-nowrap"
+            >
+              <Gear size={20} className="mr-1.5 lg:mr-2 shrink-0" weight="duotone" />
+              {t('navigation.settings')}
+            </Button>
+          </div>
         </div>
       </Card>
     </motion.div>


### PR DESCRIPTION
Closes #287

## Summary

Optimizes the MeticAI home screen for iPhone SE (375×667) so all main features are visible above the fold without scrolling.

### Changes

**1. Compact Header (mobile only)**
- Logo: 48px → 36px
- Title: `text-5xl` → `text-4xl`
- Bottom margin: `mb-10` → `mb-6`
- Desktop unchanged via `lg:` breakpoints

**2. Two-Column Button Grid**
- 6 action buttons arranged in a 2×3 grid on mobile (`grid-cols-2`)
- Button height: `h-14` → `h-12` on mobile
- Text: `text-base` → `text-sm` on mobile with `whitespace-normal` for wrapping
- Desktop reverts to single-column stacked layout via `lg:grid-cols-1`

**3. Control Center Moved Up**
- Passed as a `controlCenter` prop into StartView
- Rendered between greeting and buttons (was below the card)
- Desktop right-column placement unchanged

**4. Responsive Only**
- All changes use mobile-first Tailwind (`h-12`, `text-sm`, `grid-cols-2`)
- Desktop preserved with `lg:` variants (`lg:h-14`, `lg:text-base`, `lg:grid-cols-1`)

### Height Savings
| Section | Before | After | Saved |
|---------|--------|-------|-------|
| Header | ~140px | ~100px | ~40px |
| Buttons | ~396px | ~160px | ~236px |
| **Total** | **~704px** | **~430px** | **~274px** |

## How to Test
1. Open the app in Chrome DevTools → iPhone SE (375×667) responsive view
2. Verify all 6 action buttons + Settings are visible without scrolling
3. Verify Control Center appears between greeting and buttons on mobile
4. Switch to desktop viewport → confirm layout is unchanged (stacked buttons, right-column Control Center)

## Assumptions
- Settings button included in the 2×3 grid (ember accent in bottom-right)
- Generate New Profile stays full-width above the grid (primary action emphasis)
- Button text allowed to wrap on mobile via `whitespace-normal` override