### PR TITLE
fix(css): reorder platform theme imports after Tailwind

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -14,9 +14,10 @@ import './i18n/config'
 
 import "./main.css"
 import "./styles/theme.css"
+import "./index.css"
+// Platform themes must load AFTER Tailwind (index.css) to override utilities
 import "./styles/ios-theme.css"
 import "./styles/material-theme.css"
-import "./index.css"
 
 // In direct mode (PWA on machine), intercept MeticAI proxy API calls and either
 // translate them to Meticulous-native /api/v1/ endpoints or return empty responses.


### PR DESCRIPTION
## Bug

Platform theme CSS (ios-theme.css, material-theme.css) was imported **before** `index.css` (Tailwind) in `main.tsx`. This caused Tailwind utility classes to appear later in the CSS bundle, overriding theme rules in the cascade. Result: themes appeared very subtle/invisible.

## Fix

Move platform theme imports after `index.css` so they load last and properly override Tailwind utilities.

**Before:** themes at char ~2K, Tailwind at ~72K (Tailwind wins)
**After:** Tailwind at ~72K, themes at ~542K (themes win)

## Verification
- ✅ Build succeeds
- ✅ 416 frontend tests pass
- ✅ CSS bundle confirmed: themes now after Tailwind utilities