### PR TITLE
feat(control-center): custom profile dropdown with image, title, and …

### DIFF
--- a/apps/server/api/routes/profiles.py
+++ b/apps/server/api/routes/profiles.py
@@ -1714,7 +1714,10 @@ async def list_machine_profiles(request: Request):
                 if variables:
                     profile_dict["variables"] = deep_convert_to_dict(variables)
                 if display:
-                    profile_dict["display"] = deep_convert_to_dict(display)
+                    display_dict = deep_convert_to_dict(display)
+                    if isinstance(display_dict, dict):
+                        display_dict.pop("image", None)
+                    profile_dict["display"] = display_dict
                 
                 # Check for existing description in history
                 if in_history:

--- a/apps/server/api/routes/profiles.py
+++ b/apps/server/api/routes/profiles.py
@@ -1708,10 +1708,13 @@ async def list_machine_profiles(request: Request):
                 }
                 stages = getattr(full_profile, 'stages', None)
                 variables = getattr(full_profile, 'variables', None)
+                display = getattr(full_profile, 'display', None)
                 if stages:
                     profile_dict["stages"] = deep_convert_to_dict(stages)
                 if variables:
                     profile_dict["variables"] = deep_convert_to_dict(variables)
+                if display:
+                    profile_dict["display"] = deep_convert_to_dict(display)
                 
                 # Check for existing description in history
                 if in_history:

--- a/apps/web/public/locales/de/translation.json
+++ b/apps/web/public/locales/de/translation.json
@@ -778,7 +778,9 @@
       "started": "Gestartet"
     },
     "profileSelector": {
-      "placeholder": "Profil wechseln…"
+      "placeholder": "Profil wechseln…",
+      "noProfiles": "Keine Profile verfügbar",
+      "noDescription": "Keine Beschreibung"
     },
     "confirm": {
       "stopTitle": "Bezug stoppen?",

--- a/apps/web/public/locales/en/translation.json
+++ b/apps/web/public/locales/en/translation.json
@@ -783,7 +783,9 @@
       "profileSelected": "Profile selected: {{name}}"
     },
     "profileSelector": {
-      "placeholder": "Switch profile…"
+      "placeholder": "Switch profile…",
+      "noProfiles": "No profiles available",
+      "noDescription": "No description"
     },
     "confirm": {
       "stopTitle": "Stop Shot?",

--- a/apps/web/public/locales/es/translation.json
+++ b/apps/web/public/locales/es/translation.json
@@ -778,7 +778,9 @@
       "started": "Iniciado"
     },
     "profileSelector": {
-      "placeholder": "Cambiar perfil…"
+      "placeholder": "Cambiar perfil…",
+      "noProfiles": "No hay perfiles disponibles",
+      "noDescription": "Sin descripción"
     },
     "confirm": {
       "stopTitle": "¿Detener extracción?",

--- a/apps/web/public/locales/fr/translation.json
+++ b/apps/web/public/locales/fr/translation.json
@@ -778,7 +778,9 @@
       "started": "Démarré"
     },
     "profileSelector": {
-      "placeholder": "Changer de profil…"
+      "placeholder": "Changer de profil…",
+      "noProfiles": "Aucun profil disponible",
+      "noDescription": "Aucune description"
     },
     "confirm": {
       "stopTitle": "Arrêter l'extraction ?",

--- a/apps/web/public/locales/it/translation.json
+++ b/apps/web/public/locales/it/translation.json
@@ -778,7 +778,9 @@
       "started": "Avviato"
     },
     "profileSelector": {
-      "placeholder": "Cambia profilo…"
+      "placeholder": "Cambia profilo…",
+      "noProfiles": "Nessun profilo disponibile",
+      "noDescription": "Nessuna descrizione"
     },
     "confirm": {
       "stopTitle": "Fermare l'estrazione?",

--- a/apps/web/public/locales/sv/translation.json
+++ b/apps/web/public/locales/sv/translation.json
@@ -783,7 +783,9 @@
       "started": "Startad"
     },
     "profileSelector": {
-      "placeholder": "Byt profil…"
+      "placeholder": "Byt profil…",
+      "noProfiles": "Inga profiler tillgängliga",
+      "noDescription": "Ingen beskrivning"
     },
     "confirm": {
       "stopTitle": "Stoppa bryggning?",

--- a/apps/web/src/components/ControlCenter.tsx
+++ b/apps/web/src/components/ControlCenter.tsx
@@ -149,6 +149,7 @@ export function ControlCenter({ machineState, onOpenLiveView }: ControlCenterPro
             author?: string
             display?: { description?: string; shortDescription?: string; image?: string }
           }
+          const isDirect = isDirectMode() || isNativePlatformFn()
           const profiles: DropdownProfile[] = (data.profiles ?? [])
             .filter((p: RawProfile) => p.name)
             .map((p: RawProfile) => ({
@@ -158,18 +159,13 @@ export function ControlCenter({ machineState, onOpenLiveView }: ControlCenterPro
               display: p.display,
               // In direct/native mode, resolve machine-relative image URLs.
               // In proxy mode, leave null — the image cache uses /api/profile/{name}/image-proxy.
-              resolvedImageUrl:
-                (isDirectMode() || isNativePlatformFn())
-                  ? resolveDisplayImage(p.display?.image)
-                  : null,
+              resolvedImageUrl: isDirect ? resolveDisplayImage(p.display?.image) : null,
             }))
           setMachineProfiles(profiles)
-          // Batch-fetch images for profiles missing display.image (proxy mode fallback)
-          fetchImagesForProfiles(profiles.map(p => p.name))
-          // Resolve author for current profile
-          if (activeProfile) {
-            const match = profiles.find(p => p.name === activeProfile)
-            setProfileAuthor(match?.author ?? null)
+          // In proxy mode, batch-fetch images only for profiles without a display image
+          if (!isDirect) {
+            const needsImage = profiles.filter(p => !p.display?.image).map(p => p.name)
+            if (needsImage.length > 0) fetchImagesForProfiles(needsImage)
           }
         }
       } catch {
@@ -177,7 +173,15 @@ export function ControlCenter({ machineState, onOpenLiveView }: ControlCenterPro
       }
     })()
     return () => { cancelled = true }
-  }, [activeProfile, fetchImagesForProfiles])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchImagesForProfiles])
+
+  // Derive profileAuthor from machineProfiles when activeProfile changes
+  useEffect(() => {
+    if (!activeProfile) return
+    const match = machineProfiles.find(p => p.name === activeProfile)
+    setProfileAuthor(match?.author ?? null)
+  }, [activeProfile, machineProfiles])
 
   // Merge display images with cached fallbacks for the dropdown
   const dropdownProfiles = useMemo<DropdownProfile[]>(() =>

--- a/apps/web/src/components/ControlCenter.tsx
+++ b/apps/web/src/components/ControlCenter.tsx
@@ -8,7 +8,7 @@
  *  • Quick-action buttons (idle) or live shot metrics (brewing)
  *  • An expand toggle that reveals ControlCenterExpanded
  */
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import { Card } from '@/components/ui/card'
@@ -22,7 +22,6 @@ import {
   Scales,
   CaretDown,
   CaretUp,
-  CaretUpDown,
   Eye,
   XCircle,
   Thermometer,
@@ -35,11 +34,12 @@ import { useMachineService } from '@/hooks/useMachineService'
 import { relativeTime } from '@/lib/timeUtils'
 import { getServerUrl } from '@/lib/config'
 import { useHaptics } from '@/hooks/useHaptics'
-import { useActionSheet } from '@/hooks/useActionSheet'
-import { useProfileImageSrc } from '@/hooks/useProfileImageSrc'
-import { Capacitor } from '@capacitor/core'
+import { useProfileImageSrc, resolveDisplayImage } from '@/hooks/useProfileImageSrc'
+import { useProfileImageCache } from '@/hooks/useProfileImageCache'
+import { isDirectMode, isNativePlatform as isNativePlatformFn } from '@/lib/machineMode'
 import { toast } from 'sonner'
 import { ControlCenterExpanded } from './ControlCenterExpanded'
+import { ProfileDropdown, type DropdownProfile } from './ProfileDropdown'
 
 // ---------------------------------------------------------------------------
 // Props
@@ -104,10 +104,9 @@ export function ControlCenter({ machineState, onOpenLiveView }: ControlCenterPro
   const prevShotsRef = useRef<number | null>(null)
   const [profileImgError, setProfileImgError] = useState(false)
   const [profileAuthor, setProfileAuthor] = useState<string | null>(null)
-  const [machineProfiles, setMachineProfiles] = useState<{ id: string; name: string }[]>([])
+  const [machineProfiles, setMachineProfiles] = useState<DropdownProfile[]>([])
   const { impact } = useHaptics()
-  const { showActionSheet } = useActionSheet()
-  const isNativePlatform = Capacitor.isNativePlatform()
+  const { getImageUrl, fetchImagesForProfiles } = useProfileImageCache()
 
   // Shared state derivation + command executor
   const {
@@ -144,15 +143,32 @@ export function ControlCenter({ machineState, onOpenLiveView }: ControlCenterPro
         const res = await fetch(`${base}/api/machine/profiles`)
         if (res.ok && !cancelled) {
           const data = await res.json()
-          const profiles = (data.profiles ?? [])
-            .filter((p: { id: string; name?: string }) => p.name)
-            .map((p: { id: string; name: string; author?: string }) => ({ id: p.id, name: p.name, author: p.author }))
+          interface RawProfile {
+            id: string
+            name?: string
+            author?: string
+            display?: { description?: string; shortDescription?: string; image?: string }
+          }
+          const profiles: DropdownProfile[] = (data.profiles ?? [])
+            .filter((p: RawProfile) => p.name)
+            .map((p: RawProfile) => ({
+              id: p.id,
+              name: p.name!,
+              author: p.author,
+              display: p.display,
+              // In direct/native mode, resolve machine-relative image URLs.
+              // In proxy mode, leave null — the image cache uses /api/profile/{name}/image-proxy.
+              resolvedImageUrl:
+                (isDirectMode() || isNativePlatformFn())
+                  ? resolveDisplayImage(p.display?.image)
+                  : null,
+            }))
           setMachineProfiles(profiles)
+          // Batch-fetch images for profiles missing display.image (proxy mode fallback)
+          fetchImagesForProfiles(profiles.map(p => p.name))
           // Resolve author for current profile
           if (activeProfile) {
-            const match = profiles.find(
-              (p: { name: string; author?: string }) => p.name === activeProfile
-            )
+            const match = profiles.find(p => p.name === activeProfile)
             setProfileAuthor(match?.author ?? null)
           }
         }
@@ -161,29 +177,27 @@ export function ControlCenter({ machineState, onOpenLiveView }: ControlCenterPro
       }
     })()
     return () => { cancelled = true }
-  }, [activeProfile])
+  }, [activeProfile, fetchImagesForProfiles])
 
-  // Profile change handler for the collapsed view selector
-  const handleChangeProfile = useCallback(async () => {
-    if (machineProfiles.length === 0) return
+  // Merge display images with cached fallbacks for the dropdown
+  const dropdownProfiles = useMemo<DropdownProfile[]>(() =>
+    machineProfiles.map(p => ({
+      ...p,
+      resolvedImageUrl: p.resolvedImageUrl || getImageUrl(p.name) || null,
+    })),
+    [machineProfiles, getImageUrl],
+  )
+
+  // Profile change handler — used by ProfileDropdown
+  const handleSelectProfile = useCallback(async (name: string) => {
     impact('light')
-    if (isNativePlatform) {
-      const names = machineProfiles.map(p => p.name)
-      const index = await showActionSheet({
-        title: t('controlCenter.profileSelector.placeholder'),
-        options: names,
-      })
-      if (index >= 0 && index < names.length) {
-        const name = names[index]
-        const res = await machine.loadProfile(name)
-        if (res.success) {
-          toast.success(t('controlCenter.toasts.profileSelected', { name }))
-        } else {
-          toast.error(res.message ?? t('controlCenter.toasts.error'))
-        }
-      }
+    const res = await machine.loadProfile(name)
+    if (res.success) {
+      toast.success(t('controlCenter.toasts.profileSelected', { name }))
+    } else {
+      toast.error(res.message ?? t('controlCenter.toasts.error'))
     }
-  }, [machineProfiles, isNativePlatform, showActionSheet, t, machine, impact])
+  }, [t, machine, impact])
 
   // 🎉 Confetti celebration for every 100th shot
   useEffect(() => {
@@ -319,15 +333,13 @@ export function ControlCenter({ machineState, onOpenLiveView }: ControlCenterPro
                   </span>
                 )}
               </div>
-              {/* Change profile button — only when idle and profiles available */}
-              {machineProfiles.length > 0 && (isIdle || isPreheating || isReady) && isConnected && (
-                <button
-                  className="shrink-0 p-1.5 rounded-md hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-                  onClick={handleChangeProfile}
-                  aria-label={t('controlCenter.profileSelector.placeholder')}
-                >
-                  <CaretUpDown size={16} weight="bold" />
-                </button>
+              {/* Change profile dropdown — only when idle and profiles available */}
+              {dropdownProfiles.length > 0 && (isIdle || isPreheating || isReady) && isConnected && (
+                <ProfileDropdown
+                  profiles={dropdownProfiles}
+                  activeProfile={activeProfile}
+                  onSelectProfile={handleSelectProfile}
+                />
               )}
               </div>
             </div>

--- a/apps/web/src/components/ProfileCatalogueView.tsx
+++ b/apps/web/src/components/ProfileCatalogueView.tsx
@@ -28,6 +28,7 @@ import { getAutoSync, setAutoSync, getAutoSyncAiDescription, setAutoSyncAiDescri
 import { useProfileImageCache } from '@/hooks/useProfileImageCache'
 import { resolveDisplayImage } from '@/hooks/useProfileImageSrc'
 import { isDirectMode, isNativePlatform } from '@/lib/machineMode'
+import { ProfileImage } from '@/components/ProfileImage'
 import { extractTagsFromPreferences, getAllTagsFromEntries, getTagColorClass } from '@/lib/tags'
 import { DeleteProfileDialog } from './DeleteProfileDialog'
 import { BulkDeleteDialog } from './BulkDeleteDialog'
@@ -119,26 +120,7 @@ function SwipeableCard({
   )
 }
 
-function ProfileImage({ imageUrl }: { imageUrl?: string }) {
-  const [error, setError] = useState(false)
-
-  return (
-    <div className="w-10 h-10 rounded-full overflow-hidden border border-border/30 shrink-0 bg-secondary/60">
-      {imageUrl && !error ? (
-        <img
-          src={imageUrl}
-          alt=""
-          className="w-full h-full object-cover"
-          onError={() => setError(true)}
-        />
-      ) : (
-        <div className="w-full h-full flex items-center justify-center">
-          <Coffee size={18} className="text-muted-foreground/40" weight="fill" />
-        </div>
-      )}
-    </div>
-  )
-}
+// ProfileImage is imported from '@/components/ProfileImage'
 
 export function ProfileCatalogueView({ onBack, onViewProfile }: ProfileCatalogueViewProps) {
   const { t } = useTranslation()

--- a/apps/web/src/components/ProfileDropdown.tsx
+++ b/apps/web/src/components/ProfileDropdown.tsx
@@ -1,0 +1,188 @@
+/**
+ * ProfileDropdown — Popover-based profile selector for the Control Center.
+ *
+ * Replaces the basic ActionSheet with a rich dropdown showing profile image,
+ * name, author, and a one-line description for each profile.
+ *
+ * Accessibility: uses aria-activedescendant on a focusable listbox container
+ * so DOM focus stays on the list while visual focus tracks the active option.
+ */
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { ProfileImage } from '@/components/ProfileImage'
+import { Check, CaretUpDown } from '@phosphor-icons/react'
+import { cn } from '@/lib/utils'
+
+export interface DropdownProfile {
+  id: string
+  name: string
+  author?: string
+  display?: {
+    description?: string
+    shortDescription?: string
+    image?: string
+  }
+  /** Resolved image URL ready for <img src> */
+  resolvedImageUrl?: string | null
+}
+
+interface ProfileDropdownProps {
+  profiles: DropdownProfile[]
+  activeProfile: string | null
+  onSelectProfile: (name: string) => void
+  disabled?: boolean
+}
+
+function optionId(profileId: string) {
+  return `profile-option-${profileId}`
+}
+
+export function ProfileDropdown({ profiles, activeProfile, onSelectProfile, disabled }: ProfileDropdownProps) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [focusIndex, setFocusIndex] = useState(-1)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // Focus the listbox when popover opens, set initial focus index
+  useEffect(() => {
+    if (open) {
+      const idx = profiles.findIndex(p => p.name === activeProfile)
+      setFocusIndex(idx >= 0 ? idx : 0)
+      // Defer focus to after Radix renders the content
+      requestAnimationFrame(() => listRef.current?.focus())
+    }
+  }, [open, profiles, activeProfile])
+
+  // Scroll focused item into view
+  useEffect(() => {
+    if (!open || focusIndex < 0) return
+    const el = listRef.current?.querySelector(`[data-index="${focusIndex}"]`)
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [open, focusIndex])
+
+  const handleSelect = useCallback((name: string) => {
+    onSelectProfile(name)
+    setOpen(false)
+  }, [onSelectProfile])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setFocusIndex(i => Math.min(i + 1, profiles.length - 1))
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setFocusIndex(i => Math.max(i - 1, 0))
+        break
+      case 'Enter':
+      case ' ':
+        e.preventDefault()
+        if (focusIndex >= 0 && focusIndex < profiles.length) {
+          handleSelect(profiles[focusIndex].name)
+        }
+        break
+      case 'Escape':
+        e.preventDefault()
+        setOpen(false)
+        break
+    }
+  }, [focusIndex, profiles, handleSelect])
+
+  const getDescription = (profile: DropdownProfile): string | undefined => {
+    return profile.display?.shortDescription || profile.display?.description
+  }
+
+  if (profiles.length === 0) return null
+
+  const activeDescendant = focusIndex >= 0 && focusIndex < profiles.length
+    ? optionId(profiles[focusIndex].id)
+    : undefined
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild disabled={disabled}>
+        <button
+          className="shrink-0 p-1.5 rounded-md hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+          aria-label={t('controlCenter.profileSelector.placeholder')}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+        >
+          <CaretUpDown size={16} weight="bold" />
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="w-[min(320px,calc(100vw-2rem))] p-0 overflow-hidden"
+      >
+        {/* Header */}
+        <div className="px-3 py-2 border-b border-border/50">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            {t('controlCenter.profileSelector.placeholder')}
+          </h4>
+        </div>
+
+        {/* Profile list — focusable container with aria-activedescendant */}
+        <div
+          ref={listRef}
+          role="listbox"
+          tabIndex={0}
+          aria-label={t('controlCenter.profileSelector.placeholder')}
+          aria-activedescendant={activeDescendant}
+          onKeyDown={handleKeyDown}
+          className="max-h-[280px] overflow-y-auto overscroll-contain py-1 outline-none"
+        >
+          {profiles.map((profile, index) => {
+            const isActive = profile.name === activeProfile
+            const isFocused = index === focusIndex
+            const desc = getDescription(profile)
+
+            return (
+              <div
+                key={profile.id}
+                id={optionId(profile.id)}
+                role="option"
+                aria-selected={isActive}
+                data-index={index}
+                className={cn(
+                  'w-full flex items-center gap-3 px-3 py-2 text-left transition-colors cursor-pointer',
+                  'min-h-[44px]',
+                  isFocused && 'bg-accent',
+                  isActive && !isFocused && 'bg-accent/50',
+                  !isFocused && !isActive && 'hover:bg-muted/50',
+                )}
+                onClick={() => handleSelect(profile.name)}
+                onMouseEnter={() => setFocusIndex(index)}
+              >
+                <ProfileImage
+                  imageUrl={profile.resolvedImageUrl ?? undefined}
+                  alt={profile.name}
+                  size="sm"
+                />
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-sm font-medium truncate">
+                      {profile.name}
+                    </span>
+                    {isActive && (
+                      <Check size={14} weight="bold" className="text-primary shrink-0" />
+                    )}
+                  </div>
+                  {(desc || profile.author) && (
+                    <span className="text-xs text-muted-foreground line-clamp-1">
+                      {desc || (profile.author ? `${t('controlCenter.labels.by')} ${profile.author}` : '')}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/ProfileDropdown.tsx
+++ b/apps/web/src/components/ProfileDropdown.tsx
@@ -172,9 +172,14 @@ export function ProfileDropdown({ profiles, activeProfile, onSelectProfile, disa
                       <Check size={14} weight="bold" className="text-primary shrink-0" />
                     )}
                   </div>
-                  {(desc || profile.author) && (
+                  {desc && (
                     <span className="text-xs text-muted-foreground line-clamp-1">
-                      {desc || (profile.author ? `${t('controlCenter.labels.by')} ${profile.author}` : '')}
+                      {desc}
+                    </span>
+                  )}
+                  {profile.author && (
+                    <span className="text-xs text-muted-foreground/70 line-clamp-1">
+                      {t('controlCenter.labels.by')} {profile.author}
                     </span>
                   )}
                 </div>

--- a/apps/web/src/components/ProfileImage.tsx
+++ b/apps/web/src/components/ProfileImage.tsx
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react'
+import { Coffee } from '@phosphor-icons/react'
+import { cn } from '@/lib/utils'
+
+const sizes = {
+  sm: { container: 'w-8 h-8', icon: 14 },
+  md: { container: 'w-10 h-10', icon: 18 },
+  lg: { container: 'w-12 h-12', icon: 24 },
+} as const
+
+interface ProfileImageProps {
+  imageUrl?: string
+  alt?: string
+  size?: keyof typeof sizes
+  className?: string
+}
+
+export function ProfileImage({ imageUrl, alt = '', size = 'md', className }: ProfileImageProps) {
+  const [error, setError] = useState(false)
+
+  // Reset error when URL changes (e.g., cached image becomes available)
+  useEffect(() => { setError(false) }, [imageUrl])
+  const s = sizes[size]
+
+  return (
+    <div className={cn(
+      s.container,
+      'rounded-full overflow-hidden border border-border/30 shrink-0 bg-secondary/60',
+      className,
+    )}>
+      {imageUrl && !error ? (
+        <img
+          src={imageUrl}
+          alt={alt}
+          className="w-full h-full object-cover"
+          onError={() => setError(true)}
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center">
+          <Coffee size={s.icon} className="text-muted-foreground/40" weight="fill" />
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
…description (#395)

Replace the basic ActionSheet profile selector with a rich Popover-based dropdown. Each profile item now shows its image, name, author, and a one-line description — giving users visual context when switching profiles.

New components:
- ProfileImage: shared component (extracted from ProfileCatalogueView) with configurable size prop and error recovery
- ProfileDropdown: Popover-based selector using aria-activedescendant pattern for proper keyboard navigation and screen reader support

Changes:
- ControlCenter: enriched profile data fetch to include display object (image, description); integrated ProfileDropdown with image cache fallback for proxy mode
- Backend: /api/machine/profiles now includes display data in response
- i18n: added noProfiles/noDescription keys to all 6 locales
- ProfileCatalogueView: updated to import shared ProfileImage