### PR TITLE
feat: Derive structural tags for profile catalogue filtering

### DIFF
--- a/apps/server/api/routes/profiles.py
+++ b/apps/server/api/routes/profiles.py
@@ -84,6 +84,28 @@ def _temperature_range(temp: float) -> str:
     return "Very high temp (94°C+)"
 
 
+def _weight_range(weight: float) -> str:
+    """Map target weight (grams) to an espresso size label matching TypeScript weightRange()."""
+    if weight <= 35:
+        return "Ristretto (\u226435g)"
+    if weight <= 44:
+        return "Normale (36\u201344g)"
+    if weight <= 54:
+        return "Lungo (45\u201354g)"
+    return "Allong\u00e9 (55g+)"
+
+
+def _pressure_range(pressure: float) -> str:
+    """Map peak pressure (bar) to a range label matching TypeScript pressureRange()."""
+    if pressure <= 4:
+        return "Low pressure (\u22644 bar)"
+    if pressure <= 7:
+        return "Medium pressure (5\u20137 bar)"
+    if pressure <= 9:
+        return "Standard pressure (8\u20139 bar)"
+    return "High pressure (10+ bar)"
+
+
 def _derive_structural_tags(profile_obj: object) -> list[str]:
     """Derive user-facing structural tags from a profile object using extract_fingerprint.
 
@@ -108,6 +130,86 @@ def _derive_structural_tags(profile_obj: object) -> list[str]:
             tags.add(_temperature_range(float(temp)))
         except (TypeError, ValueError):
             pass
+
+    final_weight = fp.get("final_weight")
+    if final_weight is not None:
+        try:
+            tags.add(_weight_range(float(final_weight)))
+        except (TypeError, ValueError):
+            pass
+
+    peak_pressure = fp.get("peak_pressure", 0)
+    try:
+        pp = float(peak_pressure)
+        if pp > 0:
+            tags.add(_pressure_range(pp))
+    except (TypeError, ValueError):
+        pass
+
+    # Adaptive detection: check for $variable references in stages
+    stages = getattr(profile_obj, "stages", None) or []
+    is_adaptive = False
+    for stage in stages:
+        dynamics = getattr(stage, "dynamics", None)
+        if dynamics:
+            for point in getattr(dynamics, "points", []) or []:
+                if len(point) >= 2:
+                    if isinstance(point[0], str) and point[0].startswith("$"):
+                        is_adaptive = True
+                    if isinstance(point[1], str) and point[1].startswith("$"):
+                        is_adaptive = True
+        for limit_obj in getattr(stage, "limits", []) or []:
+            val = getattr(limit_obj, "value", None)
+            if isinstance(val, str) and val.startswith("$"):
+                is_adaptive = True
+        for exit_obj in getattr(stage, "exit_triggers", []) or []:
+            val = getattr(exit_obj, "value", None)
+            if isinstance(val, str) and val.startswith("$"):
+                is_adaptive = True
+    if is_adaptive:
+        tags.add("Adaptive")
+
+    # Structural bloom detection (content-based)
+    if "Bloom" not in tags:
+        for stage in stages:
+            stype = (getattr(stage, "type", "") or "").lower()
+            dynamics = getattr(stage, "dynamics", None)
+            pts = getattr(dynamics, "points", []) or [] if dynamics else []
+            exits = getattr(stage, "exit_triggers", []) or []
+            has_time_exit = any((getattr(e, "type", "") or "").lower() == "time" for e in exits)
+            if stype == "flow" and has_time_exit and pts:
+                try:
+                    y_vals = [abs(float(p[1])) for p in pts if len(p) >= 2 and not (isinstance(p[1], str) and p[1].startswith("$"))]
+                    if y_vals and all(v <= 0.1 for v in y_vals):
+                        tags.add("Bloom")
+                        break
+                except (TypeError, ValueError):
+                    pass
+            if stype == "power" and has_time_exit and pts:
+                try:
+                    y_vals = [abs(float(p[1])) for p in pts if len(p) >= 2 and not (isinstance(p[1], str) and p[1].startswith("$"))]
+                    if y_vals and all(v <= 5 for v in y_vals):
+                        tags.add("Bloom")
+                        break
+                except (TypeError, ValueError):
+                    pass
+
+    # Structural pre-infusion detection (content-based)
+    if "Pre-infusion" not in tags and len(stages) >= 2:
+        first = stages[0]
+        ftype = (getattr(first, "type", "") or "").lower()
+        if ftype == "power":
+            tags.add("Pre-infusion")
+        else:
+            dynamics = getattr(first, "dynamics", None)
+            pts = getattr(dynamics, "points", []) or [] if dynamics else []
+            try:
+                y_vals = [float(p[1]) for p in pts if len(p) >= 2 and not (isinstance(p[1], str) and p[1].startswith("$"))]
+                max_y = max(y_vals) if y_vals else float("inf")
+                if (ftype == "pressure" and max_y <= 4) or (ftype == "flow" and max_y <= 2):
+                    tags.add("Pre-infusion")
+            except (TypeError, ValueError):
+                pass
 
     return sorted(tags)
 

--- a/apps/server/api/routes/profiles.py
+++ b/apps/server/api/routes/profiles.py
@@ -39,7 +39,7 @@ from services.meticulous_service import (
 )
 from services.cache_service import _get_cached_image, _set_cached_image
 from services.gemini_service import get_vision_model, PROFILING_KNOWLEDGE
-from services.profile_recommendation_service import recommendation_service, _extract_fingerprint
+from services.profile_recommendation_service import recommendation_service, extract_fingerprint
 from services.history_service import HISTORY_FILE, load_history, save_history, compute_content_hash, update_entry_sync_fields, get_entry_by_id as _get_entry_by_id, _history_lock
 from services.analysis_service import _perform_local_shot_analysis, _generate_profile_description, generate_estimated_target_curves
 from services.settings_service import load_settings
@@ -85,14 +85,15 @@ def _temperature_range(temp: float) -> str:
 
 
 def _derive_structural_tags(profile_obj: object) -> list[str]:
-    """Derive user-facing structural tags from a profile object using _extract_fingerprint.
+    """Derive user-facing structural tags from a profile object using extract_fingerprint.
 
     Must be called on the raw Meticulous profile object (with attributes),
-    NOT on a dict — _extract_fingerprint uses getattr().
+    NOT on a dict — extract_fingerprint uses getattr().
     """
     try:
-        fp = _extract_fingerprint(profile_obj)
-    except Exception:
+        fp = extract_fingerprint(profile_obj)
+    except (AttributeError, TypeError, KeyError) as exc:
+        logger.debug("Failed to extract fingerprint for structural tags: %s", exc)
         return []
 
     tags: set[str] = set()
@@ -115,7 +116,7 @@ def _derive_structural_tags_from_dict(profile_dict: dict) -> list[str]:
     """Derive structural tags from a profile stored as a plain dict.
 
     Used for offline/history fallback where profile_json is a dict.
-    Wraps the dict in a SimpleNamespace so _extract_fingerprint's getattr() calls work.
+    Wraps the dict in a SimpleNamespace so extract_fingerprint's getattr() calls work.
     """
     from types import SimpleNamespace
 
@@ -129,7 +130,8 @@ def _derive_structural_tags_from_dict(profile_dict: dict) -> list[str]:
     try:
         ns = _to_ns(profile_dict)
         return _derive_structural_tags(ns)
-    except Exception:
+    except (AttributeError, TypeError, KeyError) as exc:
+        logger.debug("Failed to derive structural tags from dict: %s", exc)
         return []
 
 # Simple placeholder SVG for profiles without images (coffee bean icon)

--- a/apps/server/api/routes/profiles.py
+++ b/apps/server/api/routes/profiles.py
@@ -39,7 +39,7 @@ from services.meticulous_service import (
 )
 from services.cache_service import _get_cached_image, _set_cached_image
 from services.gemini_service import get_vision_model, PROFILING_KNOWLEDGE
-from services.profile_recommendation_service import recommendation_service
+from services.profile_recommendation_service import recommendation_service, _extract_fingerprint
 from services.history_service import HISTORY_FILE, load_history, save_history, compute_content_hash, update_entry_sync_fields, get_entry_by_id as _get_entry_by_id, _history_lock
 from services.analysis_service import _perform_local_shot_analysis, _generate_profile_description, generate_estimated_target_curves
 from services.settings_service import load_settings
@@ -51,6 +51,86 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 IMAGE_CACHE_DIR = DATA_DIR / "image_cache"
+
+# Technique tag → PRESET_TAG label mapping (mirrors TypeScript TECHNIQUE_TO_LABEL)
+_TECHNIQUE_TO_LABEL = {
+    "pressure-profile": "Pressure-controlled",
+    "flow-profile": "Flow-controlled",
+    "mixed-profile": "Mixed-controlled",
+    "preinfusion": "Pre-infusion",
+    "bloom": "Bloom",
+    "pulse": "Pulse",
+    "flat": "Flat profile",
+    "lever": "Lever",
+    "turbo": "Turbo",
+    "ramp": "Ramp",
+    "decline": "Decline",
+    "taper": "Taper",
+}
+
+
+def _temperature_range(temp: float) -> str:
+    """Map temperature to a labelled range matching TypeScript temperatureRange()."""
+    if temp < 82:
+        return "Very low temp (<82°C)"
+    if temp <= 84:
+        return "Low temp (82\u201384°C)"
+    if temp <= 87:
+        return "Warm (85\u201387°C)"
+    if temp <= 90:
+        return "Medium temp (88\u201390°C)"
+    if temp <= 93:
+        return "High temp (91\u201393°C)"
+    return "Very high temp (94°C+)"
+
+
+def _derive_structural_tags(profile_obj: object) -> list[str]:
+    """Derive user-facing structural tags from a profile object using _extract_fingerprint.
+
+    Must be called on the raw Meticulous profile object (with attributes),
+    NOT on a dict — _extract_fingerprint uses getattr().
+    """
+    try:
+        fp = _extract_fingerprint(profile_obj)
+    except Exception:
+        return []
+
+    tags: set[str] = set()
+    for tt in fp.get("technique_tags", set()):
+        label = _TECHNIQUE_TO_LABEL.get(tt)
+        if label:
+            tags.add(label)
+
+    temp = fp.get("temperature")
+    if temp is not None:
+        try:
+            tags.add(_temperature_range(float(temp)))
+        except (TypeError, ValueError):
+            pass
+
+    return sorted(tags)
+
+
+def _derive_structural_tags_from_dict(profile_dict: dict) -> list[str]:
+    """Derive structural tags from a profile stored as a plain dict.
+
+    Used for offline/history fallback where profile_json is a dict.
+    Wraps the dict in a SimpleNamespace so _extract_fingerprint's getattr() calls work.
+    """
+    from types import SimpleNamespace
+
+    def _to_ns(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return SimpleNamespace(**{k: _to_ns(v) for k, v in obj.items()})
+        if isinstance(obj, list):
+            return [_to_ns(item) for item in obj]
+        return obj
+
+    try:
+        ns = _to_ns(profile_dict)
+        return _derive_structural_tags(ns)
+    except Exception:
+        return []
 
 # Simple placeholder SVG for profiles without images (coffee bean icon)
 PLACEHOLDER_SVG = b'''<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 256 256">
@@ -1704,7 +1784,8 @@ async def list_machine_profiles(request: Request):
                     "final_weight": getattr(full_profile, 'final_weight', getattr(partial_profile, 'final_weight', None)),
                     "in_history": in_history,
                     "has_description": False,
-                    "description": None
+                    "description": None,
+                    "derived_tags": _derive_structural_tags(full_profile),
                 }
                 stages = getattr(full_profile, 'stages', None)
                 variables = getattr(full_profile, 'variables', None)
@@ -1749,6 +1830,7 @@ async def list_machine_profiles(request: Request):
                     "has_description": False,
                     "description": None,
                     "user_preferences": None,
+                    "derived_tags": _derive_structural_tags(partial_profile),
                 }
                 profiles.append(profile_dict)
         
@@ -1789,6 +1871,7 @@ async def list_machine_profiles(request: Request):
                     "in_history": True,
                     "has_description": bool(entry.get("reply")),
                     "user_preferences": entry.get("user_preferences"),
+                    "derived_tags": _derive_structural_tags_from_dict(pj) if pj else [],
                 })
             return {
                 "status": "success",

--- a/apps/server/services/profile_recommendation_service.py
+++ b/apps/server/services/profile_recommendation_service.py
@@ -61,7 +61,7 @@ def _cache_key(tags: list[str], limit: int) -> str:
 # Structural fingerprint extraction
 # ---------------------------------------------------------------------------
 
-def _extract_fingerprint(profile: object) -> dict:
+def extract_fingerprint(profile: object) -> dict:
     """Extract a structural fingerprint from a full profile.
 
     Returns a dict with:
@@ -281,7 +281,7 @@ def _score_profile(
     reasons: list[str] = []
     score = 0.0
 
-    cand_fp = _extract_fingerprint(candidate)
+    cand_fp = extract_fingerprint(candidate)
     cand_tags = _extract_name_tags(candidate)
 
     # --- Stage structure (35 points) ---
@@ -454,7 +454,7 @@ class ProfileRecommendationService:
         if source is None:
             return []
 
-        source_fp = _extract_fingerprint(source)
+        source_fp = extract_fingerprint(source)
         source_tags = _extract_name_tags(source)
 
         scored: list[dict] = []

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -4022,10 +4022,12 @@ class TestMachineProfilesEndpoint:
         profile1 = next(p for p in data["profiles"] if p["name"] == "Espresso Classic")
         assert profile1["in_history"] is True
         assert profile1["has_description"] is True
+        assert "derived_tags" in profile1
         
         # Check second profile has no history
         profile2 = next(p for p in data["profiles"] if p["name"] == "Light Roast")
         assert profile2["in_history"] is False
+        assert "derived_tags" in profile2
 
     @patch('api.routes.profiles.async_list_profiles', new_callable=AsyncMock)
     def test_list_profiles_api_error(self, mock_list_profiles, client):
@@ -4129,6 +4131,77 @@ class TestMachineProfilesEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert data["profiles"][0]["in_history"] is True
+
+    @patch('api.routes.profiles.async_get_profile', new_callable=AsyncMock)
+    @patch('api.routes.profiles.async_list_profiles', new_callable=AsyncMock)
+    @patch('api.routes.profiles.load_history', return_value=[])
+    def test_list_profiles_includes_derived_tags(self, mock_load_history, mock_list_profiles, mock_get_profile, client):
+        """Test that profile list includes derived structural tags."""
+        # Create a profile with pressure stages (triggers Pressure-controlled + Pre-infusion tags)
+        mock_profile = type('Profile', (), {})()
+        mock_profile.id = "profile-1"
+        mock_profile.name = "Classic Espresso"
+        mock_profile.error = None
+
+        # Build full profile with stages as objects (getattr-compatible)
+        dynamics = type('Dynamics', (), {'points': [[0, 2.0], [5, 4.0]], 'over': 'time', 'interpolation': 'linear'})()
+        stage1 = type('Stage', (), {'name': 'Preinfusion', 'type': 'pressure', 'dynamics': dynamics, 'limits': [], 'exit_triggers': []})()
+        dynamics2 = type('Dynamics', (), {'points': [[0, 9.0], [25, 8.5]], 'over': 'time', 'interpolation': 'linear'})()
+        stage2 = type('Stage', (), {'name': 'Extraction', 'type': 'pressure', 'dynamics': dynamics2, 'limits': [], 'exit_triggers': []})()
+
+        full_profile = type('FullProfile', (), {})()
+        full_profile.id = "profile-1"
+        full_profile.name = "Classic Espresso"
+        full_profile.author = "Barista"
+        full_profile.temperature = 92.0
+        full_profile.final_weight = 36.0
+        full_profile.stages = [stage1, stage2]
+        full_profile.variables = None
+        full_profile.display = None
+        full_profile.error = None
+
+        mock_list_profiles.return_value = [mock_profile]
+        mock_get_profile.return_value = full_profile
+
+        response = client.get("/api/machine/profiles")
+
+        assert response.status_code == 200
+        data = response.json()
+        profile = data["profiles"][0]
+        assert "derived_tags" in profile
+        assert isinstance(profile["derived_tags"], list)
+        assert "Pressure-controlled" in profile["derived_tags"]
+        assert "Pre-infusion" in profile["derived_tags"]
+        assert "High temp (91\u201393\u00b0C)" in profile["derived_tags"]
+
+    @patch('api.routes.profiles.async_get_profile', new_callable=AsyncMock)
+    @patch('api.routes.profiles.async_list_profiles', new_callable=AsyncMock)
+    @patch('api.routes.profiles.load_history', return_value=[])
+    def test_list_profiles_derived_tags_empty_without_stages(self, mock_load_history, mock_list_profiles, mock_get_profile, client):
+        """Test that profiles without stages still get derived_tags (possibly just temperature)."""
+        mock_profile = type('Profile', (), {})()
+        mock_profile.id = "profile-1"
+        mock_profile.name = "Simple"
+        mock_profile.error = None
+
+        full_profile = type('FullProfile', (), {})()
+        full_profile.id = "profile-1"
+        full_profile.name = "Simple"
+        full_profile.author = None
+        full_profile.temperature = 88.0
+        full_profile.final_weight = None
+        full_profile.error = None
+
+        mock_list_profiles.return_value = [mock_profile]
+        mock_get_profile.return_value = full_profile
+
+        response = client.get("/api/machine/profiles")
+
+        assert response.status_code == 200
+        profile = response.json()["profiles"][0]
+        assert "derived_tags" in profile
+        # Should at least have temperature tag
+        assert "Medium temp (88\u201390\u00b0C)" in profile["derived_tags"]
 
 
 class TestMachineProfileJsonEndpoint:

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -4173,6 +4173,8 @@ class TestMachineProfilesEndpoint:
         assert "Pressure-controlled" in profile["derived_tags"]
         assert "Pre-infusion" in profile["derived_tags"]
         assert "High temp (91\u201393\u00b0C)" in profile["derived_tags"]
+        assert "Normale (36\u201344g)" in profile["derived_tags"]
+        assert "Standard pressure (8\u20139 bar)" in profile["derived_tags"]
 
     @patch('api.routes.profiles.async_get_profile', new_callable=AsyncMock)
     @patch('api.routes.profiles.async_list_profiles', new_callable=AsyncMock)
@@ -4202,6 +4204,63 @@ class TestMachineProfilesEndpoint:
         assert "derived_tags" in profile
         # Should at least have temperature tag
         assert "Medium temp (88\u201390\u00b0C)" in profile["derived_tags"]
+
+    @patch('api.routes.profiles.async_get_profile', new_callable=AsyncMock)
+    @patch('api.routes.profiles.async_list_profiles', new_callable=AsyncMock)
+    @patch('api.routes.profiles.load_history', return_value=[])
+    def test_derived_tags_weight_range(self, mock_load_history, mock_list_profiles, mock_get_profile, client):
+        """Test that derived tags include weight range labels."""
+        mock_profile = type('Profile', (), {'id': 'p1', 'name': 'Ristretto', 'error': None})()
+        dynamics = type('Dynamics', (), {'points': [[0, 9.0]], 'over': 'time', 'interpolation': 'linear'})()
+        stage = type('Stage', (), {'name': 'Main', 'type': 'pressure', 'dynamics': dynamics, 'limits': [], 'exit_triggers': []})()
+        full = type('Full', (), {
+            'id': 'p1', 'name': 'Ristretto', 'author': None, 'temperature': 93.0,
+            'final_weight': 25.0, 'stages': [stage], 'variables': None, 'display': None, 'error': None
+        })()
+        mock_list_profiles.return_value = [mock_profile]
+        mock_get_profile.return_value = full
+        response = client.get("/api/machine/profiles")
+        tags = response.json()["profiles"][0]["derived_tags"]
+        assert "Ristretto (\u226435g)" in tags
+
+    @patch('api.routes.profiles.async_get_profile', new_callable=AsyncMock)
+    @patch('api.routes.profiles.async_list_profiles', new_callable=AsyncMock)
+    @patch('api.routes.profiles.load_history', return_value=[])
+    def test_derived_tags_adaptive_detection(self, mock_load_history, mock_list_profiles, mock_get_profile, client):
+        """Test that profiles with $variable references get Adaptive tag."""
+        mock_profile = type('Profile', (), {'id': 'p1', 'name': 'Adaptive', 'error': None})()
+        dynamics = type('Dynamics', (), {'points': [[0, '$pressure']], 'over': 'time', 'interpolation': 'linear'})()
+        stage = type('Stage', (), {'name': 'Main', 'type': 'pressure', 'dynamics': dynamics, 'limits': [], 'exit_triggers': []})()
+        full = type('Full', (), {
+            'id': 'p1', 'name': 'Adaptive Profile', 'author': None, 'temperature': 93.0,
+            'final_weight': 40.0, 'stages': [stage], 'variables': None, 'display': None, 'error': None
+        })()
+        mock_list_profiles.return_value = [mock_profile]
+        mock_get_profile.return_value = full
+        response = client.get("/api/machine/profiles")
+        tags = response.json()["profiles"][0]["derived_tags"]
+        assert "Adaptive" in tags
+
+    @patch('api.routes.profiles.async_get_profile', new_callable=AsyncMock)
+    @patch('api.routes.profiles.async_list_profiles', new_callable=AsyncMock)
+    @patch('api.routes.profiles.load_history', return_value=[])
+    def test_derived_tags_structural_bloom(self, mock_load_history, mock_list_profiles, mock_get_profile, client):
+        """Test content-based bloom detection from zero-flow stage with time exit."""
+        mock_profile = type('Profile', (), {'id': 'p1', 'name': 'TestProfile', 'error': None})()
+        bloom_dyn = type('Dynamics', (), {'points': [[0, 0.0], [5, 0.0]], 'over': 'time', 'interpolation': 'linear'})()
+        time_exit = type('Exit', (), {'type': 'time', 'value': 30})()
+        bloom_stage = type('Stage', (), {'name': 'Phase1', 'type': 'flow', 'dynamics': bloom_dyn, 'limits': [], 'exit_triggers': [time_exit]})()
+        main_dyn = type('Dynamics', (), {'points': [[0, 3.0]], 'over': 'time', 'interpolation': 'linear'})()
+        main_stage = type('Stage', (), {'name': 'Phase2', 'type': 'flow', 'dynamics': main_dyn, 'limits': [], 'exit_triggers': []})()
+        full = type('Full', (), {
+            'id': 'p1', 'name': 'TestProfile', 'author': None, 'temperature': 90.0,
+            'final_weight': 40.0, 'stages': [bloom_stage, main_stage], 'variables': None, 'display': None, 'error': None
+        })()
+        mock_list_profiles.return_value = [mock_profile]
+        mock_get_profile.return_value = full
+        response = client.get("/api/machine/profiles")
+        tags = response.json()["profiles"][0]["derived_tags"]
+        assert "Bloom" in tags
 
 
 class TestMachineProfileJsonEndpoint:

--- a/apps/server/test_recommendations.py
+++ b/apps/server/test_recommendations.py
@@ -14,7 +14,7 @@ os.environ.setdefault("TEST_MODE", "true")
 
 from services.profile_recommendation_service import (
     _jaccard,
-    _extract_fingerprint,
+    extract_fingerprint,
     _extract_name_tags,
     _score_profile,
     _proximity_score,
@@ -165,7 +165,7 @@ class TestProximityScore:
 
 class TestExtractFingerprint:
     def test_pressure_profile(self):
-        fp = _extract_fingerprint(PRESSURE_PROFILE)
+        fp = extract_fingerprint(PRESSURE_PROFILE)
         assert fp["control_mode"] == "pressure"
         assert fp["has_preinfusion"] is True
         assert fp["stage_count"] == 3
@@ -174,7 +174,7 @@ class TestExtractFingerprint:
         assert "preinfusion" in fp["technique_tags"]
 
     def test_flow_profile_with_bloom(self):
-        fp = _extract_fingerprint(FLOW_PROFILE)
+        fp = extract_fingerprint(FLOW_PROFILE)
         assert fp["control_mode"] == "flow"
         assert fp["has_bloom"] is True
         assert fp["has_preinfusion"] is True
@@ -182,26 +182,26 @@ class TestExtractFingerprint:
         assert "bloom" in fp["technique_tags"]
 
     def test_flat_profile(self):
-        fp = _extract_fingerprint(FLAT_PROFILE)
+        fp = extract_fingerprint(FLAT_PROFILE)
         assert fp["is_flat"] is True
         assert fp["stage_count"] == 1
         assert "flat" in fp["technique_tags"]
 
     def test_turbo_profile(self):
-        fp = _extract_fingerprint(TURBO_PROFILE)
+        fp = extract_fingerprint(TURBO_PROFILE)
         assert fp["control_mode"] == "flow"
         assert fp["temperature"] == 96.0
         assert fp["final_weight"] == 20.0
 
     def test_lever_with_decline(self):
-        fp = _extract_fingerprint(LEVER_PROFILE)
+        fp = extract_fingerprint(LEVER_PROFILE)
         assert fp["has_preinfusion"] is True
         assert "decline" in fp["technique_tags"]
         assert fp["peak_pressure"] >= 9.0
 
     def test_empty_stages(self):
         profile = _make_profile("Empty", stages=[])
-        fp = _extract_fingerprint(profile)
+        fp = extract_fingerprint(profile)
         assert fp["stage_count"] == 0
         assert fp["control_mode"] == "unknown"
         assert fp["peak_pressure"] == 0
@@ -209,7 +209,7 @@ class TestExtractFingerprint:
     def test_pulse_detection_many_stages(self):
         stages = [_make_stage(f"Step {i}", "pressure", [[0, 3], [1, 6]]) for i in range(6)]
         profile = _make_profile("Pulse Profile", stages=stages)
-        fp = _extract_fingerprint(profile)
+        fp = extract_fingerprint(profile)
         assert fp["has_pulse"] is True
         assert "pulse" in fp["technique_tags"]
 
@@ -244,14 +244,14 @@ class TestExtractNameTags:
 
 class TestScoreProfile:
     def test_similar_pressure_profiles_score_high(self):
-        source_fp = _extract_fingerprint(PRESSURE_PROFILE)
+        source_fp = extract_fingerprint(PRESSURE_PROFILE)
         source_tags = _extract_name_tags(PRESSURE_PROFILE)
         score, reasons, explanation = _score_profile(source_tags, source_fp, LEVER_PROFILE)
         # Both pressure-controlled with preinfusion
         assert score > 30
 
     def test_different_control_modes_score_lower(self):
-        source_fp = _extract_fingerprint(PRESSURE_PROFILE)
+        source_fp = extract_fingerprint(PRESSURE_PROFILE)
         source_tags = _extract_name_tags(PRESSURE_PROFILE)
         score_pressure, _, _ = _score_profile(source_tags, source_fp, LEVER_PROFILE)
         score_flow, _, _ = _score_profile(source_tags, source_fp, TURBO_PROFILE)
@@ -282,13 +282,13 @@ class TestScoreProfile:
 
     def test_score_capped_at_100(self):
         # Even with maximum overlap, score should not exceed 100
-        source_fp = _extract_fingerprint(PRESSURE_PROFILE)
+        source_fp = extract_fingerprint(PRESSURE_PROFILE)
         source_tags = _extract_name_tags(PRESSURE_PROFILE)
         score, _, _ = _score_profile(source_tags, source_fp, PRESSURE_PROFILE)
         assert score <= 100
 
     def test_explanation_is_string(self):
-        source_fp = _extract_fingerprint(PRESSURE_PROFILE)
+        source_fp = extract_fingerprint(PRESSURE_PROFILE)
         source_tags = _extract_name_tags(PRESSURE_PROFILE)
         _, _, explanation = _score_profile(source_tags, source_fp, LEVER_PROFILE)
         assert isinstance(explanation, str)

--- a/apps/web/src/components/ProfileCatalogueView.tsx
+++ b/apps/web/src/components/ProfileCatalogueView.tsx
@@ -29,7 +29,7 @@ import { useProfileImageCache } from '@/hooks/useProfileImageCache'
 import { resolveDisplayImage } from '@/hooks/useProfileImageSrc'
 import { isDirectMode, isNativePlatform } from '@/lib/machineMode'
 import { ProfileImage } from '@/components/ProfileImage'
-import { extractTagsFromPreferences, getAllTagsFromEntries, getTagColorClass } from '@/lib/tags'
+import { extractTagsFromPreferences, getTagColorClass } from '@/lib/tags'
 import { DeleteProfileDialog } from './DeleteProfileDialog'
 import { BulkDeleteDialog } from './BulkDeleteDialog'
 import { OrphanResolutionDialog } from './OrphanResolutionDialog'
@@ -45,6 +45,7 @@ interface MachineProfile {
   in_history: boolean
   has_description: boolean
   user_preferences?: string | null
+  derived_tags?: string[]
   display?: {
     description?: string
     shortDescription?: string
@@ -389,18 +390,25 @@ export function ProfileCatalogueView({ onBack, onViewProfile }: ProfileCatalogue
     orphanedEntries.some((e) => e.profile_name === profileName)
 
   const availableTags = useMemo(() => {
-    return getAllTagsFromEntries(profiles)
+    const allTags = new Set<string>()
+    for (const profile of profiles) {
+      const prefTags = extractTagsFromPreferences(profile.user_preferences ?? null)
+      for (const tag of prefTags) allTags.add(tag)
+      for (const tag of profile.derived_tags ?? []) allTags.add(tag)
+    }
+    return Array.from(allTags).sort()
   }, [profiles])
 
   const filteredProfiles = useMemo(() => {
     if (selectedFilterTags.length === 0) return profiles
 
     return profiles.filter((profile) => {
-      const entryTags = extractTagsFromPreferences(profile.user_preferences ?? null)
+      const prefTags = extractTagsFromPreferences(profile.user_preferences ?? null)
+      const merged = new Set([...prefTags, ...(profile.derived_tags ?? [])])
       if (filterMode === 'AND') {
-        return selectedFilterTags.every((tag) => entryTags.includes(tag))
+        return selectedFilterTags.every((tag) => merged.has(tag))
       }
-      return selectedFilterTags.some((tag) => entryTags.includes(tag))
+      return selectedFilterTags.some((tag) => merged.has(tag))
     })
   }, [profiles, selectedFilterTags, filterMode])
 
@@ -801,10 +809,11 @@ export function ProfileCatalogueView({ onBack, onViewProfile }: ProfileCatalogue
                               )}
                             </div>
                             {(() => {
-                              const entryTags = extractTagsFromPreferences(profile.user_preferences ?? null)
-                              return entryTags.length > 0 ? (
+                              const prefTags = extractTagsFromPreferences(profile.user_preferences ?? null)
+                              const allTags = [...new Set([...prefTags, ...(profile.derived_tags ?? [])])].sort()
+                              return allTags.length > 0 ? (
                                 <div className="flex flex-wrap gap-1 mt-2">
-                                  {entryTags.slice(0, 4).map((tag) => (
+                                  {allTags.slice(0, 4).map((tag) => (
                                     <Badge
                                       key={tag}
                                       className={`px-1.5 py-0.5 text-[10px] font-medium border ${getTagColorClass(tag, false)}`}
@@ -812,9 +821,9 @@ export function ProfileCatalogueView({ onBack, onViewProfile }: ProfileCatalogue
                                       {tag}
                                     </Badge>
                                   ))}
-                                  {entryTags.length > 4 && (
+                                  {allTags.length > 4 && (
                                     <Badge className="px-1.5 py-0.5 text-[10px] font-medium bg-muted/50 border-transparent text-muted-foreground">
-                                      +{entryTags.length - 4}
+                                      +{allTags.length - 4}
                                     </Badge>
                                   )}
                                 </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -819,6 +819,8 @@ ul:not([class]) li::before,
 .tag-process      { background-color: var(--color-indigo-200);  border-color: var(--color-indigo-500);  color: var(--color-indigo-950); }
 .tag-technique    { background-color: var(--color-cyan-200);    border-color: var(--color-cyan-500);    color: var(--color-cyan-950); }
 .tag-temperature  { background-color: var(--color-lime-200);    border-color: var(--color-lime-600);    color: var(--color-lime-950); }
+.tag-weight       { background-color: var(--color-fuchsia-200);  border-color: var(--color-fuchsia-500); color: var(--color-fuchsia-950); }
+.tag-pressure     { background-color: var(--color-red-200);      border-color: var(--color-red-500);     color: var(--color-red-950); }
 .tag-default      { background-color: var(--color-gray-200);    border-color: var(--color-gray-500);    color: var(--color-gray-950); }
 
 @media (hover: hover) {
@@ -832,6 +834,8 @@ ul:not([class]) li::before,
   .tag-process:hover      { background-color: var(--color-indigo-300);  border-color: var(--color-indigo-600); }
   .tag-technique:hover    { background-color: var(--color-cyan-300);    border-color: var(--color-cyan-600); }
   .tag-temperature:hover  { background-color: var(--color-lime-300);    border-color: var(--color-lime-700); }
+  .tag-weight:hover       { background-color: var(--color-fuchsia-300);  border-color: var(--color-fuchsia-600); }
+  .tag-pressure:hover     { background-color: var(--color-red-300);      border-color: var(--color-red-600); }
 }
 
 .dark .tag-body         { background-color: color-mix(in oklab, var(--color-amber-500)   20%, transparent); border-color: color-mix(in oklab, var(--color-amber-500)   40%, transparent); color: var(--color-amber-200); }
@@ -844,6 +848,8 @@ ul:not([class]) li::before,
 .dark .tag-process      { background-color: color-mix(in oklab, var(--color-indigo-500)  20%, transparent); border-color: color-mix(in oklab, var(--color-indigo-500)  40%, transparent); color: var(--color-indigo-200); }
 .dark .tag-technique    { background-color: color-mix(in oklab, var(--color-cyan-500)    20%, transparent); border-color: color-mix(in oklab, var(--color-cyan-500)    40%, transparent); color: var(--color-cyan-200); }
 .dark .tag-temperature  { background-color: color-mix(in oklab, var(--color-lime-500)    20%, transparent); border-color: color-mix(in oklab, var(--color-lime-500)    40%, transparent); color: var(--color-lime-200); }
+.dark .tag-weight       { background-color: color-mix(in oklab, var(--color-fuchsia-500)  20%, transparent); border-color: color-mix(in oklab, var(--color-fuchsia-500) 40%, transparent); color: var(--color-fuchsia-200); }
+.dark .tag-pressure     { background-color: color-mix(in oklab, var(--color-red-500)      20%, transparent); border-color: color-mix(in oklab, var(--color-red-500)     40%, transparent); color: var(--color-red-200); }
 .dark .tag-default      { background-color: color-mix(in oklab, var(--color-gray-500)    20%, transparent); border-color: color-mix(in oklab, var(--color-gray-500)    40%, transparent); color: var(--color-gray-200); }
 
 @media (hover: hover) {
@@ -857,6 +863,8 @@ ul:not([class]) li::before,
   .dark .tag-process:hover      { background-color: color-mix(in oklab, var(--color-indigo-500)  30%, transparent); border-color: color-mix(in oklab, var(--color-indigo-500)  55%, transparent); }
   .dark .tag-technique:hover    { background-color: color-mix(in oklab, var(--color-cyan-500)    30%, transparent); border-color: color-mix(in oklab, var(--color-cyan-500)    55%, transparent); }
   .dark .tag-temperature:hover  { background-color: color-mix(in oklab, var(--color-lime-500)    30%, transparent); border-color: color-mix(in oklab, var(--color-lime-500)    55%, transparent); }
+  .dark .tag-weight:hover       { background-color: color-mix(in oklab, var(--color-fuchsia-500)  30%, transparent); border-color: color-mix(in oklab, var(--color-fuchsia-500) 55%, transparent); }
+  .dark .tag-pressure:hover     { background-color: color-mix(in oklab, var(--color-red-500)      30%, transparent); border-color: color-mix(in oklab, var(--color-red-500)     55%, transparent); }
 }
 
 /* Selected tag states */
@@ -870,6 +878,8 @@ ul:not([class]) li::before,
 .tag-process-selected      { background-color: var(--color-indigo-600);  border-color: var(--color-indigo-700); }
 .tag-technique-selected    { background-color: var(--color-cyan-600);    border-color: var(--color-cyan-700); }
 .tag-temperature-selected  { background-color: var(--color-lime-600);    border-color: var(--color-lime-700); }
+.tag-weight-selected       { background-color: var(--color-fuchsia-600);  border-color: var(--color-fuchsia-700); }
+.tag-pressure-selected     { background-color: var(--color-red-600);      border-color: var(--color-red-700); }
 
 .dark .tag-body-selected         { background-color: var(--color-amber-500);   border-color: var(--color-amber-400); }
 .dark .tag-flavor-selected       { background-color: var(--color-rose-500);    border-color: var(--color-rose-400); }
@@ -881,6 +891,8 @@ ul:not([class]) li::before,
 .dark .tag-process-selected      { background-color: var(--color-indigo-500);  border-color: var(--color-indigo-400); }
 .dark .tag-technique-selected    { background-color: var(--color-cyan-500);    border-color: var(--color-cyan-400); }
 .dark .tag-temperature-selected  { background-color: var(--color-lime-500);    border-color: var(--color-lime-400); }
+.dark .tag-weight-selected       { background-color: var(--color-fuchsia-500);  border-color: var(--color-fuchsia-400); }
+.dark .tag-pressure-selected     { background-color: var(--color-red-500);      border-color: var(--color-red-400); }
 
 /* Score badge color classes for match percentage */
 .score-high    { background-color: var(--color-emerald-100); border-color: var(--color-emerald-500); color: var(--color-emerald-800); }

--- a/apps/web/src/lib/profileAnalysis.test.ts
+++ b/apps/web/src/lib/profileAnalysis.test.ts
@@ -9,6 +9,8 @@ import { describe, it, expect } from 'vitest'
 import {
   extractFingerprint,
   extractNameTags,
+  temperatureRange,
+  deriveStructuralTags,
   type AnalyzableProfile,
   type ProfileStage,
 } from './profileAnalysis'
@@ -265,6 +267,128 @@ describe('extractNameTags', () => {
     expect(tags.has('soak')).toBe(true)
     expect(tags.has('extraction')).toBe(true)
     expect(tags.has('hold')).toBe(true)
+  })
+})
+
+// ── temperatureRange tests ─────────────────────────────────────────────────
+
+describe('temperatureRange', () => {
+  it('maps < 82 to very low', () => {
+    expect(temperatureRange(80)).toBe('Very low temp (<82°C)')
+    expect(temperatureRange(81.9)).toBe('Very low temp (<82°C)')
+  })
+
+  it('maps 82–84 to low', () => {
+    expect(temperatureRange(82)).toBe('Low temp (82–84°C)')
+    expect(temperatureRange(84)).toBe('Low temp (82–84°C)')
+  })
+
+  it('maps 85–87 to warm', () => {
+    expect(temperatureRange(85)).toBe('Warm (85–87°C)')
+    expect(temperatureRange(87)).toBe('Warm (85–87°C)')
+  })
+
+  it('maps 88–90 to medium', () => {
+    expect(temperatureRange(88)).toBe('Medium temp (88–90°C)')
+    expect(temperatureRange(90)).toBe('Medium temp (88–90°C)')
+  })
+
+  it('maps 91–93 to high', () => {
+    expect(temperatureRange(91)).toBe('High temp (91–93°C)')
+    expect(temperatureRange(93)).toBe('High temp (91–93°C)')
+  })
+
+  it('maps 94+ to very high', () => {
+    expect(temperatureRange(94)).toBe('Very high temp (94°C+)')
+    expect(temperatureRange(100)).toBe('Very high temp (94°C+)')
+  })
+})
+
+// ── deriveStructuralTags tests ────────────────────────────────────────────
+
+describe('deriveStructuralTags', () => {
+  it('derives pressure-controlled + pre-infusion + temperature for pressure profile', () => {
+    const tags = deriveStructuralTags(PRESSURE_PROFILE)
+    expect(tags).toContain('Pressure-controlled')
+    expect(tags).toContain('Pre-infusion')
+    expect(tags).toContain('Ramp')
+    expect(tags).toContain('High temp (91–93°C)')
+  })
+
+  it('derives flow-controlled + bloom + pre-infusion for flow profile', () => {
+    const tags = deriveStructuralTags(FLOW_PROFILE)
+    expect(tags).toContain('Flow-controlled')
+    expect(tags).toContain('Bloom')
+    expect(tags).toContain('Pre-infusion')
+    expect(tags).toContain('Medium temp (88–90°C)')
+  })
+
+  it('derives flat profile + pressure-controlled for flat profile', () => {
+    const tags = deriveStructuralTags(FLAT_PROFILE)
+    expect(tags).toContain('Flat profile')
+    expect(tags).toContain('Pressure-controlled')
+    expect(tags).toContain('High temp (91–93°C)')
+  })
+
+  it('derives turbo + flow-controlled + very high temp for turbo profile', () => {
+    const tags = deriveStructuralTags(TURBO_PROFILE)
+    expect(tags).toContain('Turbo')
+    expect(tags).toContain('Flow-controlled')
+    expect(tags).toContain('Very high temp (94°C+)')
+  })
+
+  it('derives decline + pressure-controlled for lever profile', () => {
+    const tags = deriveStructuralTags(LEVER_PROFILE)
+    expect(tags).toContain('Decline')
+    expect(tags).toContain('Pressure-controlled')
+    expect(tags).toContain('Pre-infusion')
+    expect(tags).toContain('High temp (91–93°C)')
+    // Note: "Lever" is in profile NAME (extractNameTags), not stage names (extractFingerprint)
+  })
+
+  it('returns only flat + temperature for empty profile (no stages, no temperature)', () => {
+    const profile: AnalyzableProfile = { name: 'Empty', stages: [] }
+    const tags = deriveStructuralTags(profile)
+    // 0 stages: isFlat stays true (initial value), no temperature
+    expect(tags).toEqual(['Flat profile'])
+  })
+
+  it('includes flat + temperature tag when profile has no stages but has temperature', () => {
+    const profile: AnalyzableProfile = { name: 'Bare', stages: [], temperature: 90 }
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toEqual(['Flat profile', 'Medium temp (88–90°C)'])
+  })
+
+  it('returns sorted array', () => {
+    const tags = deriveStructuralTags(PRESSURE_PROFILE)
+    const sorted = [...tags].sort()
+    expect(tags).toEqual(sorted)
+  })
+
+  it('produces no duplicate tags', () => {
+    const tags = deriveStructuralTags(LEVER_PROFILE)
+    expect(new Set(tags).size).toBe(tags.length)
+  })
+
+  it('derives mixed-controlled for mixed profile', () => {
+    const stages = [
+      makeStage('Pressure Phase', 'pressure', [[0, 4], [5, 9]]),
+      makeStage('Flow Phase', 'flow', [[0, 2], [10, 2]]),
+    ]
+    const profile = makeProfile('Mixed', stages, 88)
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Mixed-controlled')
+    expect(tags).toContain('Medium temp (88–90°C)')
+  })
+
+  it('derives pulse for many-stage profile', () => {
+    const stages = Array.from({ length: 6 }, (_, i) =>
+      makeStage(`Step ${i}`, 'pressure', [[0, 3], [1, 6]])
+    )
+    const profile = makeProfile('Pulse Test', stages, 92)
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Pulse')
+    expect(tags).toContain('Pressure-controlled')
   })
 })
 

--- a/apps/web/src/lib/profileAnalysis.test.ts
+++ b/apps/web/src/lib/profileAnalysis.test.ts
@@ -346,17 +346,31 @@ describe('deriveStructuralTags', () => {
     // Note: "Lever" is in profile NAME (extractNameTags), not stage names (extractFingerprint)
   })
 
-  it('returns only flat tag for empty profile (no stages, no temperature)', () => {
+  it('returns only flat tag for explicitly empty stages array (no temperature)', () => {
     const profile: AnalyzableProfile = { name: 'Empty', stages: [] }
     const tags = deriveStructuralTags(profile)
-    // 0 stages: isFlat stays true (initial value), no temperature
+    // Explicit empty stages: isFlat stays true (initial value), no temperature
     expect(tags).toEqual(['Flat profile'])
   })
 
-  it('includes flat + temperature tag when profile has no stages but has temperature', () => {
+  it('includes flat + temperature tag when stages is empty array with temperature', () => {
     const profile: AnalyzableProfile = { name: 'Bare', stages: [], temperature: 90 }
     const tags = deriveStructuralTags(profile)
     expect(tags).toEqual(['Flat profile', 'Medium temp (88–90°C)'])
+  })
+
+  it('returns empty tags when stages is undefined and no temperature (partial profile)', () => {
+    const profile: AnalyzableProfile = { name: 'Partial' }
+    const tags = deriveStructuralTags(profile)
+    // No stages data → cannot determine techniques; no temperature → no tags
+    expect(tags).toEqual([])
+  })
+
+  it('returns only temperature tag when stages is undefined but temperature is set', () => {
+    const profile: AnalyzableProfile = { name: 'Partial', temperature: 94 }
+    const tags = deriveStructuralTags(profile)
+    // Partial profile from list endpoint: only temperature tag
+    expect(tags).toEqual(['Very high temp (94°C+)'])
   })
 
   it('returns sorted array', () => {

--- a/apps/web/src/lib/profileAnalysis.test.ts
+++ b/apps/web/src/lib/profileAnalysis.test.ts
@@ -10,6 +10,8 @@ import {
   extractFingerprint,
   extractNameTags,
   temperatureRange,
+  weightRange,
+  pressureRange,
   deriveStructuralTags,
   type AnalyzableProfile,
   type ProfileStage,
@@ -313,6 +315,8 @@ describe('deriveStructuralTags', () => {
     expect(tags).toContain('Pre-infusion')
     expect(tags).toContain('Ramp')
     expect(tags).toContain('High temp (91–93°C)')
+    expect(tags).toContain('Normale (36–44g)')
+    expect(tags).toContain('Standard pressure (8–9 bar)')
   })
 
   it('derives flow-controlled + bloom + pre-infusion for flow profile', () => {
@@ -321,6 +325,7 @@ describe('deriveStructuralTags', () => {
     expect(tags).toContain('Bloom')
     expect(tags).toContain('Pre-infusion')
     expect(tags).toContain('Medium temp (88–90°C)')
+    expect(tags).toContain('Normale (36–44g)')
   })
 
   it('derives flat profile + pressure-controlled for flat profile', () => {
@@ -328,6 +333,8 @@ describe('deriveStructuralTags', () => {
     expect(tags).toContain('Flat profile')
     expect(tags).toContain('Pressure-controlled')
     expect(tags).toContain('High temp (91–93°C)')
+    expect(tags).toContain('Normale (36–44g)')
+    expect(tags).toContain('Medium pressure (5–7 bar)')
   })
 
   it('derives turbo + flow-controlled + very high temp for turbo profile', () => {
@@ -335,6 +342,7 @@ describe('deriveStructuralTags', () => {
     expect(tags).toContain('Turbo')
     expect(tags).toContain('Flow-controlled')
     expect(tags).toContain('Very high temp (94°C+)')
+    expect(tags).toContain('Ristretto (≤35g)')
   })
 
   it('derives decline + pressure-controlled for lever profile', () => {
@@ -343,34 +351,54 @@ describe('deriveStructuralTags', () => {
     expect(tags).toContain('Pressure-controlled')
     expect(tags).toContain('Pre-infusion')
     expect(tags).toContain('High temp (91–93°C)')
-    // Note: "Lever" is in profile NAME (extractNameTags), not stage names (extractFingerprint)
+    expect(tags).toContain('Normale (36–44g)')
+    expect(tags).toContain('Standard pressure (8–9 bar)')
   })
 
   it('returns only flat tag for explicitly empty stages array (no temperature)', () => {
     const profile: AnalyzableProfile = { name: 'Empty', stages: [] }
     const tags = deriveStructuralTags(profile)
-    // Explicit empty stages: isFlat stays true (initial value), no temperature
     expect(tags).toEqual(['Flat profile'])
   })
 
-  it('includes flat + temperature tag when stages is empty array with temperature', () => {
-    const profile: AnalyzableProfile = { name: 'Bare', stages: [], temperature: 90 }
+  it('includes flat + temperature + weight tag when stages is empty array', () => {
+    const profile: AnalyzableProfile = { name: 'Bare', stages: [], temperature: 90, final_weight: 40 }
     const tags = deriveStructuralTags(profile)
-    expect(tags).toEqual(['Flat profile', 'Medium temp (88–90°C)'])
+    expect(tags).toContain('Flat profile')
+    expect(tags).toContain('Medium temp (88–90°C)')
+    expect(tags).toContain('Normale (36–44g)')
   })
 
-  it('returns empty tags when stages is undefined and no temperature (partial profile)', () => {
+  it('returns empty tags when stages is undefined and no data (partial profile)', () => {
     const profile: AnalyzableProfile = { name: 'Partial' }
     const tags = deriveStructuralTags(profile)
-    // No stages data → cannot determine techniques; no temperature → no tags
     expect(tags).toEqual([])
   })
 
-  it('returns only temperature tag when stages is undefined but temperature is set', () => {
-    const profile: AnalyzableProfile = { name: 'Partial', temperature: 94 }
+  it('returns temp + weight tags for partial profile', () => {
+    const profile: AnalyzableProfile = { name: 'Partial', temperature: 94, final_weight: 50 }
     const tags = deriveStructuralTags(profile)
-    // Partial profile from list endpoint: only temperature tag
-    expect(tags).toEqual(['Very high temp (94°C+)'])
+    expect(tags).toContain('Very high temp (94°C+)')
+    expect(tags).toContain('Lungo (45–54g)')
+  })
+
+  it('name-based bloom fallback for partial profile', () => {
+    const profile: AnalyzableProfile = { name: 'Ramp Bloom Special', temperature: 90 }
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Bloom')
+    expect(tags).toContain('Medium temp (88–90°C)')
+  })
+
+  it('name-based pre-infusion fallback for partial profile', () => {
+    const profile: AnalyzableProfile = { name: 'Slow Preinfusion for High Extraction', temperature: 90 }
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Pre-infusion')
+  })
+
+  it('name-based soak fallback for partial profile', () => {
+    const profile: AnalyzableProfile = { name: 'Long Soak Profile' }
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Bloom')
   })
 
   it('returns sorted array', () => {
@@ -403,6 +431,167 @@ describe('deriveStructuralTags', () => {
     const tags = deriveStructuralTags(profile)
     expect(tags).toContain('Pulse')
     expect(tags).toContain('Pressure-controlled')
+  })
+
+  // ── Structural bloom detection ──
+  it('detects bloom from zero-flow stage with time exit', () => {
+    const bloomStage: ProfileStage = {
+      name: 'Stage 1',
+      type: 'flow',
+      dynamics: { points: [[0, 0.0], [300, 0.0]], over: 'time', interpolation: 'linear' },
+      exit_triggers: [{ type: 'time', value: 300, relative: true, comparison: '>=' }],
+    }
+    const extractionStage = makeStage('Stage 2', 'flow', [[0, 2.5], [20, 2.0]])
+    const profile = makeProfile('No Bloom In Name', [bloomStage, extractionStage], 90)
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Bloom')
+  })
+
+  it('detects bloom from low-power stage with time exit', () => {
+    const bloomStage: ProfileStage = {
+      name: 'Stage 1',
+      type: 'power',
+      dynamics: { points: [[0, 0], [30, 0]], over: 'time', interpolation: 'linear' },
+      exit_triggers: [{ type: 'time', value: 30, relative: true, comparison: '>=' }],
+    }
+    const extractionStage = makeStage('Stage 2', 'pressure', [[0, 6], [20, 6]])
+    const profile = makeProfile('No Bloom Name', [bloomStage, extractionStage], 88)
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Bloom')
+  })
+
+  // ── Structural pre-infusion detection ──
+  it('detects pre-infusion from power-type first stage', () => {
+    const fillStage: ProfileStage = {
+      name: 'Fill',
+      type: 'power',
+      dynamics: { points: [[0, 100]], over: 'time', interpolation: 'linear' },
+      exit_triggers: [{ type: 'pressure', value: 1.0, relative: false, comparison: '>=' }],
+    }
+    const extractionStage = makeStage('Extract', 'pressure', [[0, 9], [20, 9]])
+    const profile = makeProfile('No PI Name', [fillStage, extractionStage], 88)
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Pre-infusion')
+  })
+
+  it('detects pre-infusion from low-pressure first stage', () => {
+    const piStage = makeStage('Stage 1', 'pressure', [[0, 2], [5, 3]])
+    const mainStage = makeStage('Stage 2', 'pressure', [[0, 9], [20, 8]])
+    const profile = makeProfile('No PI Name', [piStage, mainStage], 90)
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Pre-infusion')
+  })
+
+  it('detects pre-infusion from low-flow first stage', () => {
+    const piStage = makeStage('Stage 1', 'flow', [[0, 1.5], [5, 1.5]])
+    const mainStage = makeStage('Stage 2', 'pressure', [[0, 9], [20, 8]])
+    const profile = makeProfile('No PI Name', [piStage, mainStage], 90)
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Pre-infusion')
+  })
+
+  it('does not detect pre-infusion when first stage has high pressure', () => {
+    const mainStage = makeStage('Stage 1', 'pressure', [[0, 9], [20, 8]])
+    const secondStage = makeStage('Stage 2', 'pressure', [[0, 6], [10, 6]])
+    const profile = makeProfile('High Start', [mainStage, secondStage], 90)
+    const tags = deriveStructuralTags(profile)
+    expect(tags).not.toContain('Pre-infusion')
+  })
+
+  // ── Adaptive detection ──
+  it('detects adaptive tag from $variable in dynamics', () => {
+    const adaptiveStage: ProfileStage = {
+      name: 'Hold',
+      type: 'flow',
+      dynamics: { points: [[0, '$flow_Hold_Rate']], over: 'time', interpolation: 'curve' },
+    }
+    const profile: AnalyzableProfile = {
+      name: 'Adaptive Test',
+      stages: [adaptiveStage],
+      temperature: 88,
+    }
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Adaptive')
+  })
+
+  it('detects adaptive tag from $variable in limits', () => {
+    const stage: ProfileStage = {
+      name: 'Ramp',
+      type: 'flow',
+      dynamics: { points: [[0, 8], [20, 8]], over: 'time', interpolation: 'curve' },
+      limits: [{ type: 'pressure', value: '$pressure_Peak' }],
+    }
+    const profile: AnalyzableProfile = { name: 'Var Limit', stages: [stage], temperature: 88 }
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Adaptive')
+  })
+
+  it('detects adaptive tag from $variable in exit_triggers', () => {
+    const stage: ProfileStage = {
+      name: 'Fill',
+      type: 'power',
+      dynamics: { points: [[0, 100]], over: 'time', interpolation: 'linear' },
+      exit_triggers: [{ type: 'pressure', value: '$pressure_1', relative: false, comparison: '>=' }],
+    }
+    const secondStage = makeStage('Extract', 'pressure', [[0, 9], [20, 9]])
+    const profile: AnalyzableProfile = { name: 'Var Exit', stages: [stage, secondStage], temperature: 84 }
+    const tags = deriveStructuralTags(profile)
+    expect(tags).toContain('Adaptive')
+    expect(tags).toContain('Pre-infusion')
+  })
+
+  it('does not detect adaptive for profiles without $variables', () => {
+    const tags = deriveStructuralTags(PRESSURE_PROFILE)
+    expect(tags).not.toContain('Adaptive')
+  })
+})
+
+// ── weightRange tests ─────────────────────────────────────────────────────
+
+describe('weightRange', () => {
+  it('maps ≤35g to Ristretto', () => {
+    expect(weightRange(20)).toBe('Ristretto (≤35g)')
+    expect(weightRange(35)).toBe('Ristretto (≤35g)')
+  })
+
+  it('maps 36-44g to Normale', () => {
+    expect(weightRange(36)).toBe('Normale (36–44g)')
+    expect(weightRange(44)).toBe('Normale (36–44g)')
+  })
+
+  it('maps 45-54g to Lungo', () => {
+    expect(weightRange(45)).toBe('Lungo (45–54g)')
+    expect(weightRange(54)).toBe('Lungo (45–54g)')
+  })
+
+  it('maps 55g+ to Allongé', () => {
+    expect(weightRange(55)).toBe('Allongé (55g+)')
+    expect(weightRange(100)).toBe('Allongé (55g+)')
+    expect(weightRange(300)).toBe('Allongé (55g+)')
+  })
+})
+
+// ── pressureRange tests ───────────────────────────────────────────────────
+
+describe('pressureRange', () => {
+  it('maps ≤4 bar to Low', () => {
+    expect(pressureRange(2)).toBe('Low pressure (≤4 bar)')
+    expect(pressureRange(4)).toBe('Low pressure (≤4 bar)')
+  })
+
+  it('maps 5-7 bar to Medium', () => {
+    expect(pressureRange(5)).toBe('Medium pressure (5–7 bar)')
+    expect(pressureRange(7)).toBe('Medium pressure (5–7 bar)')
+  })
+
+  it('maps 8-9 bar to Standard', () => {
+    expect(pressureRange(8)).toBe('Standard pressure (8–9 bar)')
+    expect(pressureRange(9)).toBe('Standard pressure (8–9 bar)')
+  })
+
+  it('maps 10+ bar to High', () => {
+    expect(pressureRange(10)).toBe('High pressure (10+ bar)')
+    expect(pressureRange(12)).toBe('High pressure (10+ bar)')
   })
 })
 

--- a/apps/web/src/lib/profileAnalysis.test.ts
+++ b/apps/web/src/lib/profileAnalysis.test.ts
@@ -346,7 +346,7 @@ describe('deriveStructuralTags', () => {
     // Note: "Lever" is in profile NAME (extractNameTags), not stage names (extractFingerprint)
   })
 
-  it('returns only flat + temperature for empty profile (no stages, no temperature)', () => {
+  it('returns only flat tag for empty profile (no stages, no temperature)', () => {
     const profile: AnalyzableProfile = { name: 'Empty', stages: [] }
     const tags = deriveStructuralTags(profile)
     // 0 stages: isFlat stays true (initial value), no temperature

--- a/apps/web/src/lib/profileAnalysis.ts
+++ b/apps/web/src/lib/profileAnalysis.ts
@@ -266,18 +266,28 @@ const TECHNIQUE_TO_LABEL: Record<string, string> = {
  * Derive user-facing structural tags from a profile's stage data.
  * Returns sorted PRESET_TAG labels (e.g. "Bloom", "Flow-controlled", "High temp (91–93°C)").
  * Pure function — no side effects, no caching.
+ *
+ * When `profile.stages` is `undefined` (e.g. partial data from a list endpoint),
+ * only temperature tags are derived. When `stages` is an explicit empty array `[]`,
+ * the profile is treated as flat (intentionally empty).
  */
 export function deriveStructuralTags(profile: AnalyzableProfile): string[] {
-  const fp = extractFingerprint(profile)
   const tags = new Set<string>()
 
-  for (const tt of fp.techniqueTags) {
-    const label = TECHNIQUE_TO_LABEL[tt]
-    if (label) tags.add(label)
+  // Only run fingerprint/technique analysis when stage data is available.
+  // Without stages we can't determine control mode, techniques, or flatness.
+  if (profile.stages !== undefined) {
+    const fp = extractFingerprint(profile)
+    for (const tt of fp.techniqueTags) {
+      const label = TECHNIQUE_TO_LABEL[tt]
+      if (label) tags.add(label)
+    }
   }
 
-  if (fp.temperature != null) {
-    tags.add(temperatureRange(fp.temperature))
+  // Temperature can come from the profile directly (available even in list responses)
+  const temp = profile.temperature
+  if (temp != null) {
+    tags.add(temperatureRange(temp))
   }
 
   return [...tags].sort()

--- a/apps/web/src/lib/profileAnalysis.ts
+++ b/apps/web/src/lib/profileAnalysis.ts
@@ -41,6 +41,8 @@ export interface ProfileFingerprint {
   hasPulse: boolean
   isFlat: boolean
   peakPressure: number
+  maxFlow: number
+  isAdaptive: boolean
   stageCount: number
   techniqueTags: Set<string>
   temperature: number | null
@@ -76,24 +78,29 @@ export function extractFingerprint(profile: AnalyzableProfile): ProfileFingerpri
 
   const stageTypes: string[] = []
   let peakPressure = 0
+  let maxFlow = 0
   let hasPreinfusion = false
   let hasBloom = false
   let hasPulse = false
   let isFlat = true
+  let isAdaptive = false
   const techniqueTags = new Set<string>()
+
+  /** Check if a value is a $variable reference */
+  const isVarRef = (v: unknown): boolean => typeof v === 'string' && v.startsWith('$')
 
   for (const stage of stages) {
     const stype = (stage.type ?? '').toLowerCase()
     stageTypes.push(stype)
     const sname = (stage.name ?? '').toLowerCase()
 
-    // Preinfusion detection
+    // Preinfusion detection (name-based)
     if (sname.includes('preinfusion') || sname.includes('pre-infusion') || sname.includes('pre infusion')) {
       hasPreinfusion = true
       techniqueTags.add('preinfusion')
     }
 
-    // Bloom detection
+    // Bloom detection (name-based)
     if (sname.includes('bloom') || sname.includes('soak')) {
       hasBloom = true
       techniqueTags.add('bloom')
@@ -105,15 +112,21 @@ export function extractFingerprint(profile: AnalyzableProfile): ProfileFingerpri
       techniqueTags.add('pulse')
     }
 
-    // Extract peak pressure from dynamics points
+    // Extract peak pressure and max flow from dynamics points
     const dynamics = stage.dynamics
     if (dynamics) {
       const points = dynamics.points ?? []
       for (const point of points) {
         if (Array.isArray(point) && point.length >= 2) {
+          // Check for $variable references → adaptive
+          if (isVarRef(point[0]) || isVarRef(point[1])) {
+            isAdaptive = true
+            continue
+          }
           const yVal = Number(point[1])
-          if (!isNaN(yVal) && stype === 'pressure' && yVal > peakPressure) {
-            peakPressure = yVal
+          if (!isNaN(yVal)) {
+            if (stype === 'pressure' && yVal > peakPressure) peakPressure = yVal
+            if (stype === 'flow' && yVal > maxFlow) maxFlow = yVal
           }
         }
       }
@@ -122,7 +135,7 @@ export function extractFingerprint(profile: AnalyzableProfile): ProfileFingerpri
       if (points.length >= 2) {
         const yValues: number[] = []
         for (const p of points) {
-          if (Array.isArray(p) && p.length >= 2) {
+          if (Array.isArray(p) && p.length >= 2 && !isVarRef(p[1])) {
             const val = Number(p[1])
             if (!isNaN(val)) yValues.push(val)
           }
@@ -136,9 +149,10 @@ export function extractFingerprint(profile: AnalyzableProfile): ProfileFingerpri
       }
     }
 
-    // Extract pressure limits
+    // Extract pressure limits (also check for variable refs)
     const limits = stage.limits ?? []
     for (const limitObj of limits) {
+      if (isVarRef(limitObj.value)) { isAdaptive = true; continue }
       const ltype = (limitObj.type ?? '').toLowerCase()
       const lval = limitObj.value
       if (ltype === 'pressure' && lval != null) {
@@ -149,10 +163,77 @@ export function extractFingerprint(profile: AnalyzableProfile): ProfileFingerpri
       }
     }
 
+    // Check exit triggers for variable refs
+    const exits = stage.exit_triggers ?? []
+    for (const ex of exits) {
+      if (isVarRef(ex.value)) { isAdaptive = true }
+    }
+
     // Stage name technique keywords
     for (const kw of ['lever', 'turbo', 'ramp', 'decline', 'taper']) {
       if (sname.includes(kw)) {
         techniqueTags.add(kw)
+      }
+    }
+  }
+
+  // ── Structural bloom detection (content-based, not name-based) ──
+  // A stage with all dynamics points at near-zero flow/pressure AND a time-based exit
+  if (!hasBloom) {
+    for (const stage of stages) {
+      const stype = (stage.type ?? '').toLowerCase()
+      const pts = stage.dynamics?.points ?? []
+      const exits = stage.exit_triggers ?? []
+      const hasTimeExit = exits.some(e => (e.type ?? '').toLowerCase() === 'time')
+
+      // Zero/near-zero flow stage with time exit = bloom/soak
+      if (stype === 'flow' && hasTimeExit && pts.length > 0) {
+        const yVals = pts
+          .filter(p => Array.isArray(p) && p.length >= 2 && !isVarRef(p[1]))
+          .map(p => Math.abs(Number(p[1])))
+          .filter(v => !isNaN(v))
+        if (yVals.length > 0 && yVals.every(v => v <= 0.1)) {
+          hasBloom = true
+          techniqueTags.add('bloom')
+          break
+        }
+      }
+      // Power stage with power ≤ 5 (near-zero pump) and time exit = bloom
+      if (stype === 'power' && hasTimeExit && pts.length > 0) {
+        const yVals = pts
+          .filter(p => Array.isArray(p) && p.length >= 2 && !isVarRef(p[1]))
+          .map(p => Math.abs(Number(p[1])))
+          .filter(v => !isNaN(v))
+        if (yVals.length > 0 && yVals.every(v => v <= 5)) {
+          hasBloom = true
+          techniqueTags.add('bloom')
+          break
+        }
+      }
+    }
+  }
+
+  // ── Structural pre-infusion detection (content-based) ──
+  // First stage(s) with low pressure/flow or power-type pump fill, before higher-energy stages
+  if (!hasPreinfusion && stages.length >= 2) {
+    const first = stages[0]
+    const ftype = (first.type ?? '').toLowerCase()
+
+    // Power-type first stage = pump fill pre-infusion
+    if (ftype === 'power') {
+      hasPreinfusion = true
+      techniqueTags.add('preinfusion')
+    } else {
+      const pts = first.dynamics?.points ?? []
+      const yVals = pts
+        .filter(p => Array.isArray(p) && p.length >= 2 && !isVarRef(p[1]))
+        .map(p => Number(p[1]))
+        .filter(v => !isNaN(v))
+      const maxY = yVals.length > 0 ? Math.max(...yVals) : Infinity
+      // Low pressure first stage (≤ 4 bar) or low flow first stage (≤ 2 ml/s)
+      if ((ftype === 'pressure' && maxY <= 4) || (ftype === 'flow' && maxY <= 2)) {
+        hasPreinfusion = true
+        techniqueTags.add('preinfusion')
       }
     }
   }
@@ -194,6 +275,8 @@ export function extractFingerprint(profile: AnalyzableProfile): ProfileFingerpri
     hasPulse,
     isFlat: isFlat && stages.length <= 2,
     peakPressure: Math.round(peakPressure * 10) / 10,
+    maxFlow: Math.round(maxFlow * 10) / 10,
+    isAdaptive,
     stageCount: stages.length,
     techniqueTags,
     temperature,
@@ -244,6 +327,30 @@ export function temperatureRange(temp: number): string {
   return 'Very high temp (94°C+)'
 }
 
+// ── Weight range grouping ──────────────────────────────────────────────────
+
+/**
+ * Map a target weight (grams) to an espresso size label.
+ */
+export function weightRange(weight: number): string {
+  if (weight <= 35) return 'Ristretto (≤35g)'
+  if (weight <= 44) return 'Normale (36–44g)'
+  if (weight <= 54) return 'Lungo (45–54g)'
+  return 'Allongé (55g+)'
+}
+
+// ── Pressure range grouping ────────────────────────────────────────────────
+
+/**
+ * Map peak pressure (bar) to a human-readable range label.
+ */
+export function pressureRange(pressure: number): string {
+  if (pressure <= 4) return 'Low pressure (≤4 bar)'
+  if (pressure <= 7) return 'Medium pressure (5–7 bar)'
+  if (pressure <= 9) return 'Standard pressure (8–9 bar)'
+  return 'High pressure (10+ bar)'
+}
+
 // ── Structural tag derivation ──────────────────────────────────────────────
 
 /** Map internal fingerprint technique tags to PRESET_TAG labels. */
@@ -264,30 +371,52 @@ const TECHNIQUE_TO_LABEL: Record<string, string> = {
 
 /**
  * Derive user-facing structural tags from a profile's stage data.
- * Returns sorted PRESET_TAG labels (e.g. "Bloom", "Flow-controlled", "High temp (91–93°C)").
+ * Returns sorted PRESET_TAG labels.
  * Pure function — no side effects, no caching.
  *
  * When `profile.stages` is `undefined` (e.g. partial data from a list endpoint),
- * only temperature tags are derived. When `stages` is an explicit empty array `[]`,
- * the profile is treated as flat (intentionally empty).
+ * only temperature and weight tags are derived, plus name-based bloom/pre-infusion
+ * fallback. When `stages` is present, full fingerprint analysis runs.
  */
 export function deriveStructuralTags(profile: AnalyzableProfile): string[] {
   const tags = new Set<string>()
 
-  // Only run fingerprint/technique analysis when stage data is available.
-  // Without stages we can't determine control mode, techniques, or flatness.
   if (profile.stages !== undefined) {
+    // Full fingerprint analysis — stages available
     const fp = extractFingerprint(profile)
+
+    // Technique tags (bloom, pre-infusion, pulse, control mode, etc.)
     for (const tt of fp.techniqueTags) {
       const label = TECHNIQUE_TO_LABEL[tt]
       if (label) tags.add(label)
     }
+
+    // Pressure range (from peak pressure across all stages)
+    if (fp.peakPressure > 0) {
+      tags.add(pressureRange(fp.peakPressure))
+    }
+
+    // Adaptive/parametric profile
+    if (fp.isAdaptive) {
+      tags.add('Adaptive')
+    }
+  } else {
+    // Partial profile — name-based fallback for bloom/pre-infusion
+    const name = (profile.name ?? '').toLowerCase()
+    if (name.includes('bloom') || name.includes('soak')) tags.add('Bloom')
+    if (name.includes('preinfusion') || name.includes('pre-infusion') || name.includes('pre infusion')) tags.add('Pre-infusion')
   }
 
-  // Temperature can come from the profile directly (available even in list responses)
+  // Temperature — available even in partial profiles
   const temp = profile.temperature
   if (temp != null) {
     tags.add(temperatureRange(temp))
+  }
+
+  // Weight range — available even in partial profiles
+  const weight = profile.final_weight
+  if (weight != null) {
+    tags.add(weightRange(weight))
   }
 
   return [...tags].sort()

--- a/apps/web/src/lib/profileAnalysis.ts
+++ b/apps/web/src/lib/profileAnalysis.ts
@@ -229,3 +229,56 @@ export function extractNameTags(profile: AnalyzableProfile): Set<string> {
 
   return tags
 }
+
+// ── Temperature range grouping ─────────────────────────────────────────────
+
+/**
+ * Map a temperature to a human-readable range label matching PRESET_TAGS.
+ */
+export function temperatureRange(temp: number): string {
+  if (temp < 82) return 'Very low temp (<82°C)'
+  if (temp <= 84) return 'Low temp (82–84°C)'
+  if (temp <= 87) return 'Warm (85–87°C)'
+  if (temp <= 90) return 'Medium temp (88–90°C)'
+  if (temp <= 93) return 'High temp (91–93°C)'
+  return 'Very high temp (94°C+)'
+}
+
+// ── Structural tag derivation ──────────────────────────────────────────────
+
+/** Map internal fingerprint technique tags to PRESET_TAG labels. */
+const TECHNIQUE_TO_LABEL: Record<string, string> = {
+  'pressure-profile': 'Pressure-controlled',
+  'flow-profile': 'Flow-controlled',
+  'mixed-profile': 'Mixed-controlled',
+  'preinfusion': 'Pre-infusion',
+  'bloom': 'Bloom',
+  'pulse': 'Pulse',
+  'flat': 'Flat profile',
+  'lever': 'Lever',
+  'turbo': 'Turbo',
+  'ramp': 'Ramp',
+  'decline': 'Decline',
+  'taper': 'Taper',
+}
+
+/**
+ * Derive user-facing structural tags from a profile's stage data.
+ * Returns sorted PRESET_TAG labels (e.g. "Bloom", "Flow-controlled", "High temp (91–93°C)").
+ * Pure function — no side effects, no caching.
+ */
+export function deriveStructuralTags(profile: AnalyzableProfile): string[] {
+  const fp = extractFingerprint(profile)
+  const tags = new Set<string>()
+
+  for (const tt of fp.techniqueTags) {
+    const label = TECHNIQUE_TO_LABEL[tt]
+    if (label) tags.add(label)
+  }
+
+  if (fp.temperature != null) {
+    tags.add(temperatureRange(fp.temperature))
+  }
+
+  return [...tags].sort()
+}

--- a/apps/web/src/lib/profileRecommendation.ts
+++ b/apps/web/src/lib/profileRecommendation.ts
@@ -265,6 +265,8 @@ function buildUserFingerprint(
     hasPulse: techniqueTags.has('pulse'),
     isFlat: techniqueTags.has('flat'),
     peakPressure: 0,
+    maxFlow: 0,
+    isAdaptive: false,
     stageCount,
     techniqueTags,
     temperature: null,

--- a/apps/web/src/lib/profileRecommendation.ts
+++ b/apps/web/src/lib/profileRecommendation.ts
@@ -17,6 +17,7 @@
 import {
   extractFingerprint,
   extractNameTags,
+  temperatureRange,
   type AnalyzableProfile,
   type ProfileFingerprint,
 } from './profileAnalysis'
@@ -60,17 +61,6 @@ function proximityScore(
     return Math.round(frac * maxPoints * 10) / 10
   }
   return 0
-}
-
-// ── Temperature range grouping ─────────────────────────────────────────────
-
-function temperatureRange(temp: number): string {
-  if (temp < 82) return 'Very low temp (<82°C)'
-  if (temp <= 84) return 'Low temp (82–84°C)'
-  if (temp <= 87) return 'Warm (85–87°C)'
-  if (temp <= 90) return 'Medium temp (88–90°C)'
-  if (temp <= 93) return 'High temp (91–93°C)'
-  return 'Very high temp (94°C+)'
 }
 
 // ── Main scoring function ──────────────────────────────────────────────────

--- a/apps/web/src/lib/tags.ts
+++ b/apps/web/src/lib/tags.ts
@@ -45,6 +45,18 @@ export const PRESET_TAGS = [
   { label: 'Medium temp (88–90°C)', category: 'temperature' },
   { label: 'High temp (91–93°C)', category: 'temperature' },
   { label: 'Very high temp (94°C+)', category: 'temperature' },
+  // Weight range tags
+  { label: 'Ristretto (≤35g)', category: 'weight' },
+  { label: 'Normale (36–44g)', category: 'weight' },
+  { label: 'Lungo (45–54g)', category: 'weight' },
+  { label: 'Allongé (55g+)', category: 'weight' },
+  // Pressure range tags
+  { label: 'Low pressure (≤4 bar)', category: 'pressure' },
+  { label: 'Medium pressure (5–7 bar)', category: 'pressure' },
+  { label: 'Standard pressure (8–9 bar)', category: 'pressure' },
+  { label: 'High pressure (10+ bar)', category: 'pressure' },
+  // Structural tags
+  { label: 'Adaptive', category: 'technique' },
 ] as const
 
 export type TagCategory = typeof PRESET_TAGS[number]['category']
@@ -63,6 +75,8 @@ export const CATEGORY_COLORS: Record<TagCategory, string> = {
   process: 'tag-process',
   technique: 'tag-technique',
   temperature: 'tag-temperature',
+  weight: 'tag-weight',
+  pressure: 'tag-pressure',
 }
 
 export const CATEGORY_COLORS_SELECTED: Record<TagCategory, string> = {
@@ -76,6 +90,8 @@ export const CATEGORY_COLORS_SELECTED: Record<TagCategory, string> = {
   process: 'tag-process-selected text-white shadow-sm',
   technique: 'tag-technique-selected text-white shadow-sm',
   temperature: 'tag-temperature-selected text-white shadow-sm',
+  weight: 'tag-weight-selected text-white shadow-sm',
+  pressure: 'tag-pressure-selected text-white shadow-sm',
 }
 
 // Get category for a tag label
@@ -133,10 +149,10 @@ export function getMatchReasonColorClass(reason: string): string {
   if (lower.includes('temp')) return 'tag-temperature'
 
   // Weight reasons
-  if (lower.startsWith('target weight')) return 'tag-extraction'
+  if (lower.startsWith('target weight') || lower.includes('ristretto') || lower.includes('normale') || lower.includes('lungo') || lower.includes('allongé')) return 'tag-weight'
 
   // Pressure reasons
-  if (lower.startsWith('peak pressure')) return 'tag-process'
+  if (lower.startsWith('peak pressure') || lower.includes('pressure (')) return 'tag-pressure'
 
   // "Matching:" prefix — try to detect the category from the first matched tag
   if (lower.startsWith('matching:')) {

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -46,9 +46,7 @@ export function installDirectModeInterceptor(): void {
         ...p,
         in_history: true,
         has_description: !!(p.display?.description || p.display?.shortDescription),
-        derived_tags: ('stages' in p)
-          ? deriveStructuralTags(p as AnalyzableProfile)
-          : [],
+        derived_tags: deriveStructuralTags(p as AnalyzableProfile),
       }))
     }
     try { localStorage.setItem(PROFILE_LIST_CACHE_KEY, JSON.stringify(result)) } catch { /* ignore */ }

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -2,6 +2,7 @@ import { STORAGE_KEYS } from '@/lib/constants'
 import { createBrowserAIService } from '@/services/ai/BrowserAIService'
 import { isNativePlatform, getDefaultMachineUrl } from '@/lib/machineMode'
 import { findSimilarProfiles, getRecommendations } from '@/lib/profileRecommendation'
+import { deriveStructuralTags } from '@/lib/profileAnalysis'
 import type { AnalyzableProfile } from '@/lib/profileAnalysis'
 
 // ── Private helpers ─────────────────────────────────────────────────────────
@@ -45,6 +46,7 @@ export function installDirectModeInterceptor(): void {
         ...p,
         in_history: true,
         has_description: !!(p.display?.description || p.display?.shortDescription),
+        derived_tags: deriveStructuralTags(p as unknown as AnalyzableProfile),
       }))
     }
     try { localStorage.setItem(PROFILE_LIST_CACHE_KEY, JSON.stringify(result)) } catch { /* ignore */ }

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -46,7 +46,9 @@ export function installDirectModeInterceptor(): void {
         ...p,
         in_history: true,
         has_description: !!(p.display?.description || p.display?.shortDescription),
-        derived_tags: deriveStructuralTags(p as unknown as AnalyzableProfile),
+        derived_tags: ('stages' in p)
+          ? deriveStructuralTags(p as AnalyzableProfile)
+          : [],
       }))
     }
     try { localStorage.setItem(PROFILE_LIST_CACHE_KEY, JSON.stringify(result)) } catch { /* ignore */ }


### PR DESCRIPTION
## Summary

Expands profile catalogue structural tags with content-based analysis of stage dynamics, weights, and variable references. All tags work in both proxy (Python) and direct (Capacitor) mode.

### New Tag Categories

**Weight Range** (from `final_weight`)
- Ristretto (≤35g), Normale (36–44g), Lungo (45–54g), Allongé (55g+)

**Pressure Range** (from dynamics + limits peak pressure)
- Low (≤4 bar), Medium (5–7 bar), Standard (8–9 bar), High (10+ bar)

**Structural Bloom** (content-based, not name-based)
- Zero-flow stages with time exit (thermal soak)
- Low-power stages with time exit (pump-off bloom)

**Structural Pre-infusion** (content-based)
- Power-type first stage (pump fill)
- Low-pressure (≤4 bar) or low-flow (≤2 ml/s) first stage

**Adaptive/Parametric** (from \$variable references)
- Profiles with tunable variables in dynamics, limits, or exit triggers

**Name-based Fallback** (for partial profiles without stages)
- Bloom/pre-infusion detection from profile name when stages unavailable

### Files Changed

- `profileAnalysis.ts` — Expanded fingerprint extraction, added `weightRange()`, `pressureRange()`, structural detection
- `profileAnalysis.test.ts` — 60 tests (up from 39)
- `tags.ts` — Added weight/pressure entries to PRESET_TAGS + color mappings
- `index.css` — `tag-weight` (fuchsia) and `tag-pressure` (red) CSS classes
- `profileRecommendation.ts` — Updated fallback fingerprint for new fields
- `profiles.py` — Python backend parity for all new tag types
- `test_main.py` — 3 new Python tests for weight, adaptive, bloom tags

### Tests
- 866 TypeScript tests pass (all 38 test files)
- All Python tests pass including 3 new derived tag tests
- CI: All 6 jobs green ✅

Closes #398