### PR TITLE
iOS: force WKWebView viewport relayout on foreground resume (iPad landscape)

### DIFF
--- a/apps/web/ios/App/App/MeticulousViewController.swift
+++ b/apps/web/ios/App/App/MeticulousViewController.swift
@@ -4,13 +4,55 @@ import UIKit
 
 @objc(MeticulousViewController)
 class MeticulousViewController: CAPBridgeViewController {
+
+    private var foregroundObserver: NSObjectProtocol?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Force WKWebView to recalculate layout when returning from background.
+        // On iPad M4 Pro in landscape-lock, WKWebView can resume with stale
+        // viewport dimensions, causing the web content to render squished.
+        foregroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                self.forceWebViewRelayout()
+            }
+        }
+    }
+
+    deinit {
+        if let observer = foregroundObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // Ensure WKWebView always fills the full safe area
+        webView?.frame = view.bounds
+    }
+
+    private func forceWebViewRelayout() {
+        guard let webView = self.webView else { return }
+        let bounds = view.bounds
+        // Temporarily resize to force WKWebView to recalculate viewport
+        webView.frame = CGRect(x: 0, y: 0, width: bounds.width, height: bounds.height - 1)
+        DispatchQueue.main.async {
+            webView.frame = bounds
+            // Also tell the web content to re-evaluate
+            webView.evaluateJavaScript("window.dispatchEvent(new Event('resize'))", completionHandler: nil)
+        }
+    }
+
     override func capacitorDidLoad() {
         super.capacitorDidLoad()
 
         let plugin = MeticulousDiscoveryPlugin()
-        // Capacitor 8's SPM xcframework hides bridge behind #if $NonescapableTypes on Xcode 16.2 (Swift 6.0).
-        // KVC value(forKey:) throws NSUnknownKeyException for private Swift properties,
-        // so access the ivar directly via ObjC runtime instead.
         guard let bridge = findCapacitorBridge() else {
             NSLog("MeticAI: unable to locate Capacitor bridge for MeticulousDiscoveryPlugin registration")
             return
@@ -24,7 +66,6 @@ class MeticulousViewController: CAPBridgeViewController {
         NSLog("MeticAI: MeticulousDiscoveryPlugin registered successfully")
     }
 
-    /// Locate the private `capacitorBridge` ivar on `CAPBridgeViewController` using ObjC runtime introspection.
     private func findCapacitorBridge() -> NSObject? {
         var count: UInt32 = 0
         guard let ivars = class_copyIvarList(CAPBridgeViewController.self, &count) else { return nil }


### PR DESCRIPTION
tested fix locally on M4 iPad, and it fixes the bg-then-fg squishing which was happening upon resume.

It wasn't a JS issue, but some native issue instead.