### PR TITLE
fix(android): repair mDNS auto-detection and onboarding input jank

### DIFF
--- a/apps/web/src/components/OnboardingWizard.tsx
+++ b/apps/web/src/components/OnboardingWizard.tsx
@@ -407,7 +407,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                 value={machineIp}
                 onChange={(e) => {
                   setMachineIp(e.target.value)
-                  setConnectionStatus('idle')
+                  setConnectionStatus(prev => (prev === 'idle' ? prev : 'idle'))
                 }}
                 onKeyDown={(e) => e.key === 'Enter' && handleTestConnection()}
                 className="flex-1"
@@ -456,7 +456,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
               value={machineIp}
               onChange={(e) => {
                 setMachineIp(e.target.value)
-                setConnectionStatus('idle')
+                setConnectionStatus(prev => (prev === 'idle' ? prev : 'idle'))
               }}
               onKeyDown={(e) => e.key === 'Enter' && handleTestConnection()}
               className="flex-1"

--- a/apps/web/src/services/machine/discovery.test.ts
+++ b/apps/web/src/services/machine/discovery.test.ts
@@ -167,9 +167,9 @@ describe('discovery', () => {
         vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('timeout'))
 
         const promise = discoverMachines()
-        // The synchronous setup registers both watch callbacks before the
+        // The synchronous setup registers the single watch callback before the
         // function suspends on its discovery timeout.
-        expect(callbacks.length).toBe(2)
+        expect(callbacks.length).toBe(1)
         for (const cb of callbacks) {
           expect(() => cb(undefined)).not.toThrow()
           expect(() => cb({ action: 'added' })).not.toThrow()
@@ -177,6 +177,33 @@ describe('discovery', () => {
         }
         await vi.advanceTimersByTimeAsync(10000)
         await expect(promise).resolves.toEqual([])
+      } finally {
+        vi.useRealTimers()
+        mockedIsNative.mockReturnValue(false)
+      }
+    })
+
+    it('should watch ONLY _meticulous._tcp on native (Android single-browser constraint)', async () => {
+      // The capacitor-zeroconf JmDNS backend on Android only registers a
+      // browser on the FIRST watch() call; a second concurrent watch (e.g. a
+      // diagnostic _http._tcp browse) is silently ignored, which previously
+      // prevented the real _meticulous._tcp browse from ever starting and made
+      // auto-detection always fail on Android.
+      vi.useFakeTimers()
+      try {
+        mockedIsNative.mockReturnValue(true)
+        const { ZeroConf } = await import('capacitor-zeroconf')
+        const watchedTypes: string[] = []
+        vi.mocked(ZeroConf.watch).mockImplementation(((opts: { type: string }) => {
+          watchedTypes.push(opts.type)
+          return Promise.resolve(undefined)
+        }) as unknown as typeof ZeroConf.watch)
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('timeout'))
+
+        const promise = discoverMachines()
+        expect(watchedTypes).toEqual(['_meticulous._tcp'])
+        await vi.advanceTimersByTimeAsync(10000)
+        await promise
       } finally {
         vi.useRealTimers()
         mockedIsNative.mockReturnValue(false)

--- a/apps/web/src/services/machine/discovery.ts
+++ b/apps/web/src/services/machine/discovery.ts
@@ -48,7 +48,9 @@ export function onDiscoveryLog(listener: DiscoveryLogListener): () => void {
 function dlog(msg: string) {
   const ts = new Date().toISOString().slice(11, 23)
   const entry = `[${ts}] ${msg}`
-  console.error(`[Discovery] ${entry}`)
+  // Use console.log (not console.error): these are diagnostics, and on the
+  // Android WebView console.error is bridged/heavier, adding main-thread jank.
+  console.log(`[Discovery] ${entry}`)
   _logListeners.forEach(fn => { try { fn(entry) } catch { /* ignore */ } })
 }
 
@@ -147,26 +149,17 @@ export async function discoverMachines(): Promise<DiscoveredMachine[]> {
     })
     dlog('STEP 3: discovery state ready')
 
-    // Step 4: Start diagnostic _http._tcp browse
-    try {
-      dlog('STEP 4: starting _http._tcp diagnostic browse...')
-      ZeroConf.watch(
-        { type: '_http._tcp', domain: 'local.' },
-        (result) => {
-          const svc = result?.service
-          dlog(`[diag] _http._tcp: action=${result?.action} name=${svc?.name} host=${svc?.hostname} ipv4=${JSON.stringify(svc?.ipv4Addresses)} port=${svc?.port}`)
-        },
-      ).then(() => {
-        dlog('STEP 4: _http._tcp watch() promise resolved')
-      }).catch((e: unknown) => {
-        dlog(`STEP 4: _http._tcp watch() REJECTED: ${e}`)
-      })
-      dlog('STEP 4: _http._tcp watch() call returned (fire-and-forget)')
-    } catch (e) {
-      dlog(`STEP 4: _http._tcp watch() THREW: ${e}`)
-    }
-
-    // Step 5: Start main _meticulous._tcp browse
+    // Step 5: Start main _meticulous._tcp browse.
+    //
+    // IMPORTANT (Android): the capacitor-zeroconf JmDNS backend only registers
+    // a browser on the FIRST watch() call (ZeroConf.java guards on
+    // `browserManager == null`). Any second concurrent watch() — e.g. a
+    // diagnostic `_http._tcp` browse — is silently ignored, so the real
+    // `_meticulous._tcp` browse would never start and auto-detection would
+    // always fail. We therefore watch ONLY `_meticulous._tcp`. Browsing a
+    // single low-traffic service type also avoids flooding the WebView main
+    // thread with a callback per LAN HTTP service (which caused input focus
+    // difficulty and typing freezes during onboarding).
     try {
       dlog('STEP 5: starting _meticulous._tcp browse...')
       ZeroConf.watch(
@@ -221,7 +214,6 @@ export async function discoverMachines(): Promise<DiscoveredMachine[]> {
 
     // Step 8: Cleanup (fire-and-forget — DO NOT await; unwatch/close can hang)
     ZeroConf.unwatch({ type: '_meticulous._tcp', domain: 'local.' }).catch(() => {})
-    ZeroConf.unwatch({ type: '_http._tcp', domain: 'local.' }).catch(() => {})
     ZeroConf.close().catch(() => {})
     dlog('STEP 8: cleanup dispatched (non-blocking)')
 


### PR DESCRIPTION
## Summary

Fixes the three Android beta-test issues in the onboarding flow:

1. **Auto-detection of the Meticulous machine fails** on Android.
2. **Inputs hard to focus** during onboarding.
3. **Intermittent pause/freeze while typing** (e.g. entering the IP).

## Root cause

Discovery started a **diagnostic `_http._tcp` browse** before the real `_meticulous._tcp` browse. The `capacitor-zeroconf` JmDNS backend on **Android only registers a browser on the first `watch()` call** (it guards on `browserManager == null` in `ZeroConf.java`). The second `_meticulous._tcp` watch was therefore **silently ignored**, so auto-detection could never succeed on Android. iOS uses a per-type browser map and was unaffected.

That same `_http._tcp` browse emitted a callback for **every HTTP service on the LAN**, each logged via `console.error`, flooding the WebView main thread — which caused the focus difficulty and typing freezes.

## Changes

- Remove the diagnostic `_http._tcp` browse so `_meticulous._tcp` is the sole (and therefore registered) watch on Android.
- Lower discovery logging from `console.error` → `console.log` (lighter on the Android WebView bridge).
- Only reset connection status to `idle` on IP input change when it isn't already `idle`, avoiding redundant per-keystroke re-renders.
- Tests: assert exactly one `_meticulous._tcp` watch on native; add a regression test documenting the single-browser constraint.

## Risk / regressions

- **No native code changed** — JS/TS only.
- **iOS unaffected**: the diagnostic browse was pure noise there; `_meticulous._tcp` was already the working watch.
- **Web unaffected**: native-only code path.

## Verification

- `bun run lint` → 0 errors (68 baseline warnings).
- `bun run test:run` discovery suite → 21 passing; onboarding suite → 5 passing.
- `VITE_MACHINE_MODE=capacitor bun run build` → succeeds.
- mDNS auto-detection itself requires a real Android device on the LAN to validate (emulator is NAT'd and cannot receive multicast.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
EOF
)