### PR TITLE
feat(analysis): AI shot-analysis overhaul (#423) — deterministic ShotFacts, knowledge base, validators, compass

### DIFF
--- a/apps/server/analysis_knowledge.py
+++ b/apps/server/analysis_knowledge.py
@@ -56,7 +56,9 @@ def _fmt_num(value) -> str:
 
 def build_fact_sheet(facts: dict) -> str:
     """Render ShotFacts into compact prose for the LLM prompt (replaces raw JSON dump)."""
-    lines: list[str] = ["### Deterministic Shot Facts (authoritative — trust over raw telemetry)"]
+    lines: list[str] = [
+        "### Deterministic Shot Facts (authoritative — trust over raw telemetry)"
+    ]
 
     weight = facts.get("weight") or {}
     lines.append(
@@ -85,7 +87,11 @@ def build_fact_sheet(facts: dict) -> str:
         ca = s.get("curve_adherence")
         if ca and abs(float(ca.get("delta", 0) or 0)) >= 0.5:
             parts.append(f"curve off-target by {_fmt_num(ca.get('delta'))}")
-        lines.append(f"  - {s.get('stage_name')} [{s.get('control_mode')}]: " + "; ".join(parts) + ".")
+        lines.append(
+            f"  - {s.get('stage_name')} [{s.get('control_mode')}]: "
+            + "; ".join(parts)
+            + "."
+        )
 
     return "\n".join(lines)
 

--- a/apps/server/analysis_knowledge.py
+++ b/apps/server/analysis_knowledge.py
@@ -88,3 +88,21 @@ def build_fact_sheet(facts: dict) -> str:
         lines.append(f"  - {s.get('stage_name')} [{s.get('control_mode')}]: " + "; ".join(parts) + ".")
 
     return "\n".join(lines)
+
+
+FEW_SHOT_ANALYSIS_EXAMPLE = """\
+### Worked Example (format + reasoning reference — do not copy its numbers)
+Facts: Pre-infusion [flow] exit = Targeted (planned duration); Ramp [pressure] exit = Targeted
+(pressure threshold reached); Hold [pressure] exit = Targeted (yield reached); final weight 36 g
+(target 36 g, deviation 0%); total time 28 s.
+
+Good analysis excerpt:
+## 1. Shot Performance
+**What Happened:**
+- Pre-infusion ran its planned duration, then pressure ramped cleanly to target.
+- The hold stage ended exactly on the weight target — a correct, intentional finish.
+**Assessment:** Good
+
+Note how every claim maps to a fact, no values are invented, and the Targeted weight exit is
+described as success, not "early termination".
+"""

--- a/apps/server/analysis_knowledge.py
+++ b/apps/server/analysis_knowledge.py
@@ -1,0 +1,90 @@
+"""Analysis-specific knowledge base + fact-sheet renderer (K1 + K2).
+
+ANALYSIS_KNOWLEDGE is injected into the shot-analysis prompt (parallel to PROFILING_KNOWLEDGE)
+so small models share the same reasoning framework. build_fact_sheet renders the deterministic
+ShotFacts into compact prose that replaces the raw local-analysis JSON dump in the prompt.
+
+Mirror of apps/web/src/services/ai/analysisKnowledge.ts — keep the two texts in sync.
+"""
+
+from __future__ import annotations
+
+ANALYSIS_KNOWLEDGE = """\
+You are reasoning about a single espresso extraction. Apply this framework:
+
+EXIT TRIGGER CLASSIFICATION (critical — do not confuse intent with failure):
+- A stage ends when one of its exit triggers fires. Classify each as Targeted or Failsafe:
+  - Targeted: the stage reached the outcome it was designed for. Examples: a weight trigger
+    (yield reached), a time trigger that is the stage's ONLY trigger (planned duration), a
+    flow-controlled stage hitting its target pressure (puck resistance achieved), a
+    pressure-controlled stage hitting target pressure, or a pressure-controlled stage whose
+    ONLY trigger is flow (planned flow transition).
+  - Failsafe: a backstop fired before the real target. Examples: a time trigger firing when
+    OTHER triggers also exist (timeout), or a pressure-controlled stage exiting on a flow
+    backstop when other triggers exist (caught channeling or choking).
+- NEVER describe a Targeted exit as a problem. A short stage that hit its weight target is a
+  correct, successful outcome — not "early termination".
+
+DIAGNOSTIC SIGNALS:
+- Stall: a stage exits on a time failsafe with negligible weight gain (< 0.5 g). Indicates the
+  puck choked or flow collapsed. Suggest a coarser grind or revisiting the pressure target.
+- Channeling: pressure falls while flow rises within the same stage. Indicates an uneven puck.
+  Suggest distribution/puck-prep changes, not profile changes, as the first remedy.
+- Curve adherence: when measured average diverges from the stage's target by a meaningful margin,
+  the machine could not follow the profile — usually a grind/dose mismatch, not a profile flaw.
+
+EXTRACTION THEORY:
+- Sour/acidic => under-extraction => grind finer or raise temperature.
+- Bitter/harsh => over-extraction => grind coarser or lower temperature.
+- Weak/thin body => lower brew ratio (less water per dose) or larger dose.
+- Strong/heavy => raise brew ratio.
+
+DISCIPLINE:
+- Only state facts supported by the data provided. Do NOT invent pressures, temperatures, weights,
+  or events that are not in the fact sheet. If a value is unknown, say so.
+- Prefer one or two high-confidence, specific, numeric recommendations over many vague ones.
+"""
+
+
+def _fmt_num(value) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:g}"
+    return str(value)
+
+
+def build_fact_sheet(facts: dict) -> str:
+    """Render ShotFacts into compact prose for the LLM prompt (replaces raw JSON dump)."""
+    lines: list[str] = ["### Deterministic Shot Facts (authoritative — trust over raw telemetry)"]
+
+    weight = facts.get("weight") or {}
+    lines.append(
+        f"- Final weight: {_fmt_num(weight.get('actual'))} g "
+        f"(target {_fmt_num(weight.get('target'))} g, "
+        f"deviation {_fmt_num(weight.get('deviation_pct'))}%)."
+    )
+    lines.append(f"- Total shot time: {_fmt_num(facts.get('total_time_s'))} s.")
+
+    lines.append("- Stage-by-stage:")
+    for s in facts.get("stages", []):
+        if not s.get("reached"):
+            lines.append(f"  - {s.get('stage_name')}: not reached during this shot.")
+            continue
+        tc = s.get("trigger_class") or {}
+        parts = [f"exit = {tc.get('label', 'Unknown')}"]
+        stall = s.get("stall") or {}
+        if stall.get("stalled"):
+            parts.append(f"STALL (only {_fmt_num(stall.get('weight_gain'))} g gained)")
+        chan = s.get("channeling") or {}
+        if chan.get("channeling"):
+            parts.append(
+                f"CHANNELING (pressure -{_fmt_num(chan.get('pressure_drop'))} bar, "
+                f"flow +{_fmt_num(chan.get('flow_rise'))} ml/s)"
+            )
+        ca = s.get("curve_adherence")
+        if ca and abs(float(ca.get("delta", 0) or 0)) >= 0.5:
+            parts.append(f"curve off-target by {_fmt_num(ca.get('delta'))}")
+        lines.append(f"  - {s.get('stage_name')} [{s.get('control_mode')}]: " + "; ".join(parts) + ".")
+
+    return "\n".join(lines)

--- a/apps/server/analysis_schema.py
+++ b/apps/server/analysis_schema.py
@@ -1,0 +1,16 @@
+"""Single source of truth for the shot-analysis section structure (L2).
+
+Mirror of apps/web/src/lib/analysisSchema.ts — keep section titles identical.
+"""
+
+from __future__ import annotations
+
+REQUIRED_ANALYSIS_SECTIONS = [
+    "Shot Performance",
+    "Root Cause Analysis",
+    "Setup Recommendations",
+    "Profile Recommendations",
+    "Profile Design Observations",
+]
+
+OPTIONAL_TASTE_SECTION = "Taste-Based Recommendations"

--- a/apps/server/api/routes/shots.py
+++ b/apps/server/api/routes/shots.py
@@ -1010,15 +1010,14 @@ Target Weight: {clean_profile.get("final_weight", "Not set")}g
 ### Profile Stages
 {json.dumps(clean_profile.get("stages", []), indent=2)}
 
-## Full Local Analysis
-This is the complete algorithmic analysis of the shot. Use this data to inform your expert analysis.
+## Shot Facts (digested — authoritative; trust over raw telemetry)
+Each stage lists its exit classification. A Targeted exit means the stage reached its intended
+outcome (e.g. its weight target); a Failsafe exit means a backstop fired before the real target.
+A Targeted exit — including a short stage that hit its weight target — is NORMAL and CORRECT
+behavior; never describe it as "early termination". The final weight reflects the settled weight
+after the machine's piston retraction completes, so do NOT penalize weight deviation unless it
+exceeds ±5%.
 
-IMPORTANT: Each stage includes 'cumulative_weight_at_end' which shows the total weight when that stage ended.
-If a stage ended early but the cumulative weight was near the target weight, the shot likely terminated 
-correctly due to reaching the final weight target - this is NORMAL and EXPECTED behavior.
-A stage that appears "short" may simply mean the target yield was reached, which is the correct outcome.
-
-## Shot Facts (digested)
 {fact_sheet}
 {taste_context}
 

--- a/apps/server/api/routes/shots.py
+++ b/apps/server/api/routes/shots.py
@@ -35,6 +35,11 @@ from services.gemini_service import (
     compute_taste_hash,
 )
 from prompt_builder import build_taste_context
+from analysis_knowledge import (
+    ANALYSIS_KNOWLEDGE,
+    FEW_SHOT_ANALYSIS_EXAMPLE,
+    build_fact_sheet,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -960,6 +965,8 @@ async def analyze_shot_with_llm(
 
         # Run local analysis first to extract data
         local_analysis = _perform_local_shot_analysis(shot_data, profile_data)
+        shot_facts = local_analysis.get("shot_facts", {})
+        fact_sheet = build_fact_sheet(shot_facts)
 
         # Prepare profile data (clean, no image)
         clean_profile = _prepare_profile_for_llm(profile_data, profile_description)
@@ -993,6 +1000,9 @@ async def analyze_shot_with_llm(
 ## Expert Knowledge
 {PROFILING_KNOWLEDGE}
 
+## Analysis Framework
+{ANALYSIS_KNOWLEDGE}
+
 ## Profile Being Used
 Name: {clean_profile["name"]}
 Temperature: {clean_profile.get("temperature", "Not set")}°C
@@ -1015,8 +1025,13 @@ If a stage ended early but the cumulative weight was near the target weight, the
 correctly due to reaching the final weight target - this is NORMAL and EXPECTED behavior.
 A stage that appears "short" may simply mean the target yield was reached, which is the correct outcome.
 
-{json.dumps(local_analysis, indent=2)}
+## Shot Facts (digested)
+{fact_sheet}
 {taste_context}
+
+---
+
+{FEW_SHOT_ANALYSIS_EXAMPLE}
 
 ---
 

--- a/apps/server/api/routes/shots.py
+++ b/apps/server/api/routes/shots.py
@@ -465,12 +465,8 @@ async def get_shots_by_profile(
                     return None
 
                 shot_profile_name = shot_data.get("profile_name", "")
-                if not shot_profile_name and isinstance(
-                    shot_data.get("profile"), dict
-                ):
-                    shot_profile_name = (
-                        shot_data.get("profile", {}).get("name", "")
-                    )
+                if not shot_profile_name and isinstance(shot_data.get("profile"), dict):
+                    shot_profile_name = shot_data.get("profile", {}).get("name", "")
 
                 profile_id = ""
                 if isinstance(shot_data.get("profile"), dict):
@@ -504,9 +500,7 @@ async def get_shots_by_profile(
                     "timestamp": shot_data.get("time"),
                     "profile_name": shot_profile_name,
                     "final_weight": final_weight,
-                    "total_time": total_time_ms / 1000
-                    if total_time_ms
-                    else None,
+                    "total_time": total_time_ms / 1000 if total_time_ms else None,
                 }
                 if include_data:
                     shot_info["data"] = shot_data
@@ -524,25 +518,19 @@ async def get_shots_by_profile(
 
         # Collect matches from new scans
         new_matches = [
-            r
-            for r in scan_results
-            if r is not None and not isinstance(r, Exception)
+            r for r in scan_results if r is not None and not isinstance(r, Exception)
         ]
 
         # Combine with matches from already-indexed dates
         indexed_matches = lookup_shots_by_profile(profile_name, limit) or []
         # Filter indexed matches to only already-indexed dates
         idx_from_cache = [
-            m
-            for m in indexed_matches
-            if m["date"] in already_indexed_dates
+            m for m in indexed_matches if m["date"] in already_indexed_dates
         ]
 
         matching_shots = new_matches + idx_from_cache
         # Sort newest first, trim to limit
-        matching_shots.sort(
-            key=lambda x: x.get("timestamp") or "", reverse=True
-        )
+        matching_shots.sort(key=lambda x: x.get("timestamp") or "", reverse=True)
         matching_shots = matching_shots[:limit]
 
         logger.info(
@@ -701,9 +689,11 @@ async def analyze_shot(
                                     # Convert to list of dicts if needed
                                     if isinstance(val, list):
                                         stage_dict[attr] = [
-                                            dict(item)
-                                            if hasattr(item, "__dict__")
-                                            else item
+                                            (
+                                                dict(item)
+                                                if hasattr(item, "__dict__")
+                                                else item
+                                            )
                                             for item in val
                                         ]
                                     else:
@@ -949,9 +939,11 @@ async def analyze_shot_with_llm(
                                 if val is not None:
                                     if isinstance(val, list):
                                         stage_dict[attr] = [
-                                            dict(item)
-                                            if hasattr(item, "__dict__")
-                                            else item
+                                            (
+                                                dict(item)
+                                                if hasattr(item, "__dict__")
+                                                else item
+                                            )
                                             for item in val
                                         ]
                                     else:
@@ -1325,9 +1317,11 @@ async def get_recent_shots(request: Request, limit: int = 50, offset: int = 0):
                     result = await async_get_shot_files(date)
                     if hasattr(result, "error") and result.error:
                         return date, []
-                    return date, sorted(
-                        [f.name for f in result], reverse=True
-                    ) if result else (date, [])
+                    return date, (
+                        sorted([f.name for f in result], reverse=True)
+                        if result
+                        else (date, [])
+                    )
                 except Exception:
                     return date, []
 
@@ -1405,8 +1399,7 @@ async def get_recent_shots(request: Request, limit: int = 50, offset: int = 0):
 
         # Combine new scans with indexed data
         new_shots = [
-            r for r in scan_results
-            if r is not None and not isinstance(r, Exception)
+            r for r in scan_results if r is not None and not isinstance(r, Exception)
         ]
         # Also include already-indexed shots
         idx_shots = get_all_indexed_shots(limit=needed + 10, offset=0) or []
@@ -1414,10 +1407,7 @@ async def get_recent_shots(request: Request, limit: int = 50, offset: int = 0):
             annotation = get_annotation(shot["date"], shot["filename"])
             shot["has_annotation"] = annotation is not None
 
-        all_shots = new_shots + [
-            s for s in idx_shots
-            if s["date"] in indexed_dates
-        ]
+        all_shots = new_shots + [s for s in idx_shots if s["date"] in indexed_dates]
 
         # Sort by timestamp descending (handle None timestamps)
         all_shots.sort(

--- a/apps/server/api/routes/shots.py
+++ b/apps/server/api/routes/shots.py
@@ -35,6 +35,7 @@ from services.gemini_service import (
     compute_taste_hash,
 )
 from prompt_builder import build_taste_context
+from services.analysis_validator import validate_against_facts
 from analysis_knowledge import (
     ANALYSIS_KNOWLEDGE,
     FEW_SHOT_ANALYSIS_EXAMPLE,
@@ -1144,6 +1145,11 @@ Rules for recommendations:
         response = await model.async_generate_content(prompt)
 
         llm_analysis = response.text if response else "Analysis generation failed"
+        if not validate_against_facts(llm_analysis, shot_facts)["valid"]:
+            retry = await model.async_generate_content(prompt)
+            retry_text = retry.text if retry else llm_analysis
+            if validate_against_facts(retry_text, shot_facts)["valid"]:
+                llm_analysis = retry_text
 
         # Save to cache
         save_llm_analysis_to_cache(

--- a/apps/server/api/routes/shots.py
+++ b/apps/server/api/routes/shots.py
@@ -35,7 +35,7 @@ from services.gemini_service import (
     compute_taste_hash,
 )
 from prompt_builder import build_taste_context
-from services.analysis_validator import validate_against_facts
+from services.analysis_validator import validate_against_facts, check_structure
 from analysis_knowledge import (
     ANALYSIS_KNOWLEDGE,
     FEW_SHOT_ANALYSIS_EXAMPLE,
@@ -1145,10 +1145,17 @@ Rules for recommendations:
         response = await model.async_generate_content(prompt)
 
         llm_analysis = response.text if response else "Analysis generation failed"
-        if not validate_against_facts(llm_analysis, shot_facts)["valid"]:
+        first_ok = (
+            validate_against_facts(llm_analysis, shot_facts)["valid"]
+            and check_structure(llm_analysis)["valid"]
+        )
+        if not first_ok:
             retry = await model.async_generate_content(prompt)
             retry_text = retry.text if retry else llm_analysis
-            if validate_against_facts(retry_text, shot_facts)["valid"]:
+            if (
+                validate_against_facts(retry_text, shot_facts)["valid"]
+                and check_structure(retry_text)["valid"]
+            ):
                 llm_analysis = retry_text
 
         # Save to cache

--- a/apps/server/services/analysis_service.py
+++ b/apps/server/services/analysis_service.py
@@ -13,6 +13,7 @@ import re
 from typing import Any, Optional
 
 from services.gemini_service import get_vision_model, PROFILING_KNOWLEDGE
+from services.shot_facts import build_shot_facts
 from logging_config import get_logger
 
 logger = get_logger()
@@ -1378,7 +1379,7 @@ def _perform_local_shot_analysis(shot_data: dict, profile_data: dict) -> dict:
                 "Consider adding a weight-based exit trigger to limit pre-infusion volume"
             )
 
-    return {
+    analysis_result = {
         "shot_summary": {
             "final_weight": round(final_weight, 1),
             "target_weight": round(target_weight, 1) if target_weight else None,
@@ -1410,6 +1411,8 @@ def _perform_local_shot_analysis(shot_data: dict, profile_data: dict) -> dict:
         },
         "profile_target_curves": profile_target_curves,
     }
+    analysis_result["shot_facts"] = build_shot_facts(analysis_result)
+    return analysis_result
 
 
 def _prepare_shot_summary_for_llm(

--- a/apps/server/services/analysis_service.py
+++ b/apps/server/services/analysis_service.py
@@ -269,6 +269,33 @@ def _resolve_variable(value, variables: list) -> tuple[Any, str | None]:
     return value, var_key
 
 
+def _mean_dynamics_target(stage: dict, variables: list | None = None) -> float | None:
+    """Mean of a pressure/flow stage's resolved dynamics setpoints.
+
+    Returns the intended scalar target (bar or ml/s) used by
+    shot_facts._curve_adherence, or None for non-pressure/flow stages or when
+    no numeric setpoints are present. Mirror of the native
+    DirectModeInterceptor.meanDynamicsTarget — keep the two in sync.
+    """
+    stage_type = stage.get("type", "unknown")
+    if stage_type not in ("pressure", "flow"):
+        return None
+    variables = variables or []
+    values: list[float] = []
+    for point in stage.get("dynamics_points") or []:
+        if not isinstance(point, (list, tuple)) or len(point) == 0:
+            continue
+        raw = point[1] if len(point) > 1 else point[0]
+        resolved, _ = _resolve_variable(raw, variables)
+        try:
+            values.append(float(resolved))
+        except (TypeError, ValueError):
+            continue
+    if not values:
+        return None
+    return round(sum(values) / len(values), 2)
+
+
 def _format_exit_triggers(
     exit_triggers: list, variables: list | None = None
 ) -> list[dict]:
@@ -452,6 +479,7 @@ def _analyze_stage_execution(
         "stage_key": stage_key,
         "stage_type": stage_type,
         "profile_target": dynamics_desc,
+        "profile_target_value": _mean_dynamics_target(profile_stage, variables),
         "exit_triggers": exit_triggers,
         "limits": limits,
         "executed": shot_stage_data is not None,

--- a/apps/server/services/analysis_validator.py
+++ b/apps/server/services/analysis_validator.py
@@ -18,7 +18,9 @@ _EARLY_EXIT_PATTERNS = [
     re.compile(r"stopped?\s+before\s+reaching", re.I),
 ]
 _CHANNELING_ASSERTION = re.compile(r"\bchannel(?:ing|ed|s)?\b", re.I)
-_CHANNELING_NEGATION = re.compile(r"\b(no|not|without|absence of|isn'?t|wasn'?t)\b[^.]{0,30}channel", re.I)
+_CHANNELING_NEGATION = re.compile(
+    r"\b(no|not|without|absence of|isn'?t|wasn'?t)\b[^.]{0,30}channel", re.I
+)
 
 
 def validate_against_facts(text: str, facts: dict) -> dict:
@@ -37,7 +39,11 @@ def validate_against_facts(text: str, facts: dict) -> dict:
         issues.append("mischaracterized-targeted-exit")
 
     any_channeling = any((s.get("channeling") or {}).get("channeling") for s in stages)
-    if not any_channeling and _CHANNELING_ASSERTION.search(body) and not _CHANNELING_NEGATION.search(body):
+    if (
+        not any_channeling
+        and _CHANNELING_ASSERTION.search(body)
+        and not _CHANNELING_NEGATION.search(body)
+    ):
         issues.append("unsupported-channeling")
 
     return {"valid": len(issues) == 0, "issues": issues}

--- a/apps/server/services/analysis_validator.py
+++ b/apps/server/services/analysis_validator.py
@@ -1,0 +1,41 @@
+"""Anti-hallucination / semantic validator for shot-analysis output (K4 server parity).
+
+Mirror of validateAgainstFacts in apps/web/src/lib/analysisLint.ts — keep rules identical.
+High precision: only flag clear contradictions of the deterministic ShotFacts.
+"""
+
+from __future__ import annotations
+
+import re
+
+_EARLY_EXIT_PATTERNS = [
+    re.compile(r"terminat\w*\s+early", re.I),
+    re.compile(r"\bearly\s+terminat", re.I),
+    re.compile(r"ended?\s+(too\s+)?(early|prematurely)", re.I),
+    re.compile(r"\bcut\s+short\b", re.I),
+    re.compile(r"stopped?\s+before\s+reaching", re.I),
+]
+_CHANNELING_ASSERTION = re.compile(r"\bchannel(?:ing|ed|s)?\b", re.I)
+_CHANNELING_NEGATION = re.compile(r"\b(no|not|without|absence of|isn'?t|wasn'?t)\b[^.]{0,30}channel", re.I)
+
+
+def validate_against_facts(text: str, facts: dict) -> dict:
+    """Return {'valid': bool, 'issues': list[str]}."""
+    issues: list[str] = []
+    body = text or ""
+    stages = facts.get("stages", [])
+
+    has_targeted_weight_exit = any(
+        s.get("reached")
+        and s.get("trigger_type") == "weight"
+        and (s.get("trigger_class") or {}).get("kind") == "targeted"
+        for s in stages
+    )
+    if has_targeted_weight_exit and any(p.search(body) for p in _EARLY_EXIT_PATTERNS):
+        issues.append("mischaracterized-targeted-exit")
+
+    any_channeling = any((s.get("channeling") or {}).get("channeling") for s in stages)
+    if not any_channeling and _CHANNELING_ASSERTION.search(body) and not _CHANNELING_NEGATION.search(body):
+        issues.append("unsupported-channeling")
+
+    return {"valid": len(issues) == 0, "issues": issues}

--- a/apps/server/services/analysis_validator.py
+++ b/apps/server/services/analysis_validator.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+from analysis_schema import REQUIRED_ANALYSIS_SECTIONS
+
 _EARLY_EXIT_PATTERNS = [
     re.compile(r"terminat\w*\s+early", re.I),
     re.compile(r"\bearly\s+terminat", re.I),
@@ -39,3 +41,10 @@ def validate_against_facts(text: str, facts: dict) -> dict:
         issues.append("unsupported-channeling")
 
     return {"valid": len(issues) == 0, "issues": issues}
+
+
+def check_structure(text: str) -> dict:
+    """Verify the analysis contains each required section title (L1)."""
+    body = (text or "").lower()
+    missing = [s for s in REQUIRED_ANALYSIS_SECTIONS if s.lower() not in body]
+    return {"valid": not missing, "issues": ["missing-sections"] if missing else []}

--- a/apps/server/services/compass_rules.py
+++ b/apps/server/services/compass_rules.py
@@ -1,0 +1,39 @@
+"""Deterministic Espresso-Compass taste -> dial-in adjustment rules (D6).
+
+X axis: -1 sour ... +1 bitter.   Y axis: -1 weak/thin ... +1 strong/heavy.
+Mirrors apps/web/src/lib/compassRules.ts and the domain knowledge in
+prompt_builder.build_taste_context. Pure function — no I/O.
+"""
+
+from __future__ import annotations
+
+DEADBAND = 0.25  # within this radius of center, taste is considered balanced
+
+
+def compass_adjustments(taste_x: float, taste_y: float) -> list[dict]:
+    """Return ordered, concrete adjustment suggestions for the given taste vector."""
+    adjustments: list[dict] = []
+
+    # X axis — acidity/bitterness balance, primarily extraction yield.
+    if taste_x <= -DEADBAND:  # too sour -> under-extracted -> extract more
+        adjustments.append({"kind": "grind_finer", "axis": "x",
+                            "reason": "Sour/acidic indicates under-extraction; grind finer to raise yield."})
+        adjustments.append({"kind": "temp_up", "axis": "x",
+                            "reason": "A few degrees hotter increases extraction of sweet/bitter compounds."})
+    elif taste_x >= DEADBAND:  # too bitter -> over-extracted -> extract less
+        adjustments.append({"kind": "grind_coarser", "axis": "x",
+                            "reason": "Bitter/harsh indicates over-extraction; grind coarser to lower yield."})
+        adjustments.append({"kind": "temp_down", "axis": "x",
+                            "reason": "A few degrees cooler reduces harsh bitter extraction."})
+
+    # Y axis — strength/body, primarily ratio/dose.
+    if taste_y <= -DEADBAND:  # too weak/thin -> increase concentration
+        adjustments.append({"kind": "ratio_up", "axis": "y",
+                            "reason": "Weak/thin body; lower the brew ratio (less water per dose) for more concentration."})
+        adjustments.append({"kind": "dose_up", "axis": "y",
+                            "reason": "A larger dose increases strength and body."})
+    elif taste_y >= DEADBAND:  # too strong/heavy -> dilute
+        adjustments.append({"kind": "ratio_down", "axis": "y",
+                            "reason": "Strong/heavy; raise the brew ratio (more water per dose) to lighten."})
+
+    return adjustments

--- a/apps/server/services/compass_rules.py
+++ b/apps/server/services/compass_rules.py
@@ -16,24 +16,59 @@ def compass_adjustments(taste_x: float, taste_y: float) -> list[dict]:
 
     # X axis — acidity/bitterness balance, primarily extraction yield.
     if taste_x <= -DEADBAND:  # too sour -> under-extracted -> extract more
-        adjustments.append({"kind": "grind_finer", "axis": "x",
-                            "reason": "Sour/acidic indicates under-extraction; grind finer to raise yield."})
-        adjustments.append({"kind": "temp_up", "axis": "x",
-                            "reason": "A few degrees hotter increases extraction of sweet/bitter compounds."})
+        adjustments.append(
+            {
+                "kind": "grind_finer",
+                "axis": "x",
+                "reason": "Sour/acidic indicates under-extraction; grind finer to raise yield.",
+            }
+        )
+        adjustments.append(
+            {
+                "kind": "temp_up",
+                "axis": "x",
+                "reason": "A few degrees hotter increases extraction of sweet/bitter compounds.",
+            }
+        )
     elif taste_x >= DEADBAND:  # too bitter -> over-extracted -> extract less
-        adjustments.append({"kind": "grind_coarser", "axis": "x",
-                            "reason": "Bitter/harsh indicates over-extraction; grind coarser to lower yield."})
-        adjustments.append({"kind": "temp_down", "axis": "x",
-                            "reason": "A few degrees cooler reduces harsh bitter extraction."})
+        adjustments.append(
+            {
+                "kind": "grind_coarser",
+                "axis": "x",
+                "reason": "Bitter/harsh indicates over-extraction; grind coarser to lower yield.",
+            }
+        )
+        adjustments.append(
+            {
+                "kind": "temp_down",
+                "axis": "x",
+                "reason": "A few degrees cooler reduces harsh bitter extraction.",
+            }
+        )
 
     # Y axis — strength/body, primarily ratio/dose.
     if taste_y <= -DEADBAND:  # too weak/thin -> increase concentration
-        adjustments.append({"kind": "ratio_up", "axis": "y",
-                            "reason": "Weak/thin body; lower the brew ratio (less water per dose) for more concentration."})
-        adjustments.append({"kind": "dose_up", "axis": "y",
-                            "reason": "A larger dose increases strength and body."})
+        adjustments.append(
+            {
+                "kind": "ratio_up",
+                "axis": "y",
+                "reason": "Weak/thin body; lower the brew ratio (less water per dose) for more concentration.",
+            }
+        )
+        adjustments.append(
+            {
+                "kind": "dose_up",
+                "axis": "y",
+                "reason": "A larger dose increases strength and body.",
+            }
+        )
     elif taste_y >= DEADBAND:  # too strong/heavy -> dilute
-        adjustments.append({"kind": "ratio_down", "axis": "y",
-                            "reason": "Strong/heavy; raise the brew ratio (more water per dose) to lighten."})
+        adjustments.append(
+            {
+                "kind": "ratio_down",
+                "axis": "y",
+                "reason": "Strong/heavy; raise the brew ratio (more water per dose) to lighten.",
+            }
+        )
 
     return adjustments

--- a/apps/server/services/shot_facts.py
+++ b/apps/server/services/shot_facts.py
@@ -177,5 +177,8 @@ def build_shot_facts(local_analysis: dict) -> dict:
             "target": wa.get("target"),
             "deviation_pct": wa.get("deviation_percent"),
         },
-        "total_time_s": local_analysis.get("overall_metrics", {}).get("total_time"),
+        "total_time_s": (
+            local_analysis.get("overall_metrics", {}).get("total_time")
+            or local_analysis.get("shot_summary", {}).get("total_time")
+        ),
     }

--- a/apps/server/services/shot_facts.py
+++ b/apps/server/services/shot_facts.py
@@ -94,47 +94,71 @@ def detect_stall(stage: dict) -> dict:
     ed = stage.get("execution_data") or {}
     gain = float(ed.get("weight_gain", 0) or 0)
     klass = classify_trigger(_stage_control_mode(stage), trig_type, total)
-    stalled = klass["kind"] == "failsafe" and trig_type == "time" and gain < STALL_MIN_WEIGHT_GAIN_G
+    stalled = (
+        klass["kind"] == "failsafe"
+        and trig_type == "time"
+        and gain < STALL_MIN_WEIGHT_GAIN_G
+    )
     return {"stalled": stalled, "weight_gain": round(gain, 2)}
 
 
 def detect_channeling(execution_data: dict) -> dict:
     """Flag likely channeling: pressure falls while flow rises within the stage."""
     ed = execution_data or {}
-    p_drop = float(ed.get("start_pressure", 0) or 0) - float(ed.get("end_pressure", 0) or 0)
+    p_drop = float(ed.get("start_pressure", 0) or 0) - float(
+        ed.get("end_pressure", 0) or 0
+    )
     f_rise = float(ed.get("end_flow", 0) or 0) - float(ed.get("start_flow", 0) or 0)
-    channeling = p_drop >= CHANNELING_PRESSURE_DROP_BAR and f_rise >= CHANNELING_FLOW_RISE_MLS
-    return {"channeling": channeling, "pressure_drop": round(p_drop, 2), "flow_rise": round(f_rise, 2)}
+    channeling = (
+        p_drop >= CHANNELING_PRESSURE_DROP_BAR and f_rise >= CHANNELING_FLOW_RISE_MLS
+    )
+    return {
+        "channeling": channeling,
+        "pressure_drop": round(p_drop, 2),
+        "flow_rise": round(f_rise, 2),
+    }
 
 
 def _build_phases(local_analysis: dict) -> list[dict]:
     """Group stages into pre-infusion / ramp / peak / decline by avg pressure shape."""
-    stages = [s for s in local_analysis.get("stage_analyses", []) if s.get("execution_data")]
+    stages = [
+        s for s in local_analysis.get("stage_analyses", []) if s.get("execution_data")
+    ]
     phases: list[dict] = []
     for s in stages:
         ed = s["execution_data"]
         avg_p = float(ed.get("avg_pressure", 0) or 0)
         if avg_p < 3.0:
             phase = "pre-infusion"
-        elif float(ed.get("end_pressure", 0) or 0) > float(ed.get("start_pressure", 0) or 0):
+        elif float(ed.get("end_pressure", 0) or 0) > float(
+            ed.get("start_pressure", 0) or 0
+        ):
             phase = "ramp"
-        elif float(ed.get("end_pressure", 0) or 0) < float(ed.get("start_pressure", 0) or 0):
+        elif float(ed.get("end_pressure", 0) or 0) < float(
+            ed.get("start_pressure", 0) or 0
+        ):
             phase = "decline"
         else:
             phase = "peak"
-        phases.append({
-            "stage_name": s.get("stage_name"),
-            "phase": phase,
-            "avg_pressure": ed.get("avg_pressure"),
-            "avg_flow": ed.get("avg_flow"),
-            "weight_gain": ed.get("weight_gain"),
-        })
+        phases.append(
+            {
+                "stage_name": s.get("stage_name"),
+                "phase": phase,
+                "avg_pressure": ed.get("avg_pressure"),
+                "avg_flow": ed.get("avg_flow"),
+                "weight_gain": ed.get("weight_gain"),
+            }
+        )
     return phases
 
 
 def _curve_adherence(stage: dict) -> dict | None:
     """Compare measured avg vs the stage's first target dynamics point, if numeric."""
-    points = ((stage.get("profile_target") or {}) if isinstance(stage.get("profile_target"), dict) else {})
+    points = (
+        (stage.get("profile_target") or {})
+        if isinstance(stage.get("profile_target"), dict)
+        else {}
+    )
     target = points.get("target_value")
     ed = stage.get("execution_data") or {}
     if target is None:
@@ -143,7 +167,11 @@ def _curve_adherence(stage: dict) -> dict | None:
     measured = ed.get("avg_pressure") if mode == "pressure" else ed.get("avg_flow")
     if measured is None:
         return None
-    return {"target": target, "measured": measured, "delta": round(float(measured) - float(target), 2)}
+    return {
+        "target": target,
+        "measured": measured,
+        "delta": round(float(measured) - float(target), 2),
+    }
 
 
 def build_shot_facts(local_analysis: dict) -> dict:
@@ -158,16 +186,20 @@ def build_shot_facts(local_analysis: dict) -> dict:
         triggered = (s.get("exit_trigger_result") or {}).get("triggered") or {}
         trig_type = triggered.get("type", "")
         total = len(s.get("exit_triggers") or [])
-        stages_out.append({
-            "stage_name": s.get("stage_name"),
-            "reached": True,
-            "control_mode": _stage_control_mode(s),
-            "trigger_type": trig_type,
-            "trigger_class": classify_trigger(_stage_control_mode(s), trig_type, total),
-            "stall": detect_stall(s),
-            "channeling": detect_channeling(ed),
-            "curve_adherence": _curve_adherence(s),
-        })
+        stages_out.append(
+            {
+                "stage_name": s.get("stage_name"),
+                "reached": True,
+                "control_mode": _stage_control_mode(s),
+                "trigger_type": trig_type,
+                "trigger_class": classify_trigger(
+                    _stage_control_mode(s), trig_type, total
+                ),
+                "stall": detect_stall(s),
+                "channeling": detect_channeling(ed),
+                "curve_adherence": _curve_adherence(s),
+            }
+        )
     wa = local_analysis.get("weight_analysis", {})
     return {
         "stages": stages_out,

--- a/apps/server/services/shot_facts.py
+++ b/apps/server/services/shot_facts.py
@@ -1,0 +1,69 @@
+"""Deterministic shot-fact derivation (#423 + diagnostic signals).
+
+Pure functions: telemetry + profile + local analysis -> typed facts. No I/O, no LLM.
+Mirrors apps/web/src/lib/shotFacts.ts — keep thresholds identical across runtimes.
+"""
+
+from __future__ import annotations
+
+
+def classify_trigger(
+    stage_control_mode: str, trigger_type: str, total_triggers: int
+) -> dict:
+    """Classify a stage's exit trigger as Targeted vs Failsafe (#423).
+
+    Args:
+        stage_control_mode: the variable the stage controls ('pressure' | 'flow' | other).
+        trigger_type: the exit trigger that fired ('weight' | 'time' | 'pressure' | 'flow').
+        total_triggers: number of exit triggers defined on the stage.
+
+    Returns:
+        {'kind': 'targeted'|'failsafe'|'unknown', 'label': str, 'reason': str}
+    """
+    if trigger_type == "weight":
+        return {
+            "kind": "targeted",
+            "label": "Targeted (yield reached)",
+            "reason": "Weight is the ultimate goal of the shot.",
+        }
+    if trigger_type == "time":
+        if total_triggers == 1:
+            return {
+                "kind": "targeted",
+                "label": "Targeted (planned duration)",
+                "reason": "Time is the only trigger, so this is an intentional timed stage.",
+            }
+        return {
+            "kind": "failsafe",
+            "label": "Failsafe (timeout limit)",
+            "reason": "Stage hit its time backstop before another target was reached.",
+        }
+    if stage_control_mode == "flow" and trigger_type == "pressure":
+        return {
+            "kind": "targeted",
+            "label": "Targeted (puck resistance achieved)",
+            "reason": "Flow-controlled stage reached its intended pressure.",
+        }
+    if stage_control_mode == "pressure" and trigger_type == "flow":
+        if total_triggers == 1:
+            return {
+                "kind": "targeted",
+                "label": "Targeted (planned flow transition)",
+                "reason": "Flow is the only trigger, so the transition is intentional.",
+            }
+        return {
+            "kind": "failsafe",
+            "label": "Failsafe (caught channeling or choking)",
+            "reason": "Pressure-controlled stage exited on a flow backstop.",
+        }
+    if stage_control_mode == "pressure" and trigger_type == "pressure":
+        return {
+            "kind": "targeted",
+            "label": "Targeted (pressure threshold reached)",
+            "reason": "Pressure-controlled stage reached its target pressure.",
+        }
+    return {
+        "kind": "unknown",
+        "label": "Unknown",
+        "reason": "Trigger/control-mode combination is not classified.",
+    }

--- a/apps/server/services/shot_facts.py
+++ b/apps/server/services/shot_facts.py
@@ -153,13 +153,14 @@ def _build_phases(local_analysis: dict) -> list[dict]:
 
 
 def _curve_adherence(stage: dict) -> dict | None:
-    """Compare measured avg vs the stage's first target dynamics point, if numeric."""
-    points = (
-        (stage.get("profile_target") or {})
-        if isinstance(stage.get("profile_target"), dict)
-        else {}
-    )
-    target = points.get("target_value")
+    """Compare measured avg vs the stage's mean target setpoint, if numeric.
+
+    The numeric target is precomputed at stage-build time as
+    ``profile_target_value`` (mean of the resolved dynamics setpoints); see
+    analysis_service._mean_dynamics_target and its native mirror
+    DirectModeInterceptor.meanDynamicsTarget.
+    """
+    target = stage.get("profile_target_value")
     ed = stage.get("execution_data") or {}
     if target is None:
         return None
@@ -168,7 +169,7 @@ def _curve_adherence(stage: dict) -> dict | None:
     if measured is None:
         return None
     return {
-        "target": target,
+        "target": round(float(target), 2),
         "measured": measured,
         "delta": round(float(measured) - float(target), 2),
     }

--- a/apps/server/services/shot_facts.py
+++ b/apps/server/services/shot_facts.py
@@ -67,3 +67,115 @@ def classify_trigger(
         "label": "Unknown",
         "reason": "Trigger/control-mode combination is not classified.",
     }
+
+
+# Threshold constants — keep identical to apps/web/src/lib/shotFacts.ts
+STALL_MIN_WEIGHT_GAIN_G = 0.5  # below this on a time-failsafe = stalled
+CHANNELING_PRESSURE_DROP_BAR = 1.5  # pressure fall within a stage
+CHANNELING_FLOW_RISE_MLS = 1.5  # simultaneous flow rise
+
+
+def _stage_control_mode(stage: dict) -> str:
+    """Best-effort: which variable the stage controls."""
+    t = (stage.get("stage_type") or stage.get("type") or "").lower()
+    if "flow" in t:
+        return "flow"
+    if "pressure" in t:
+        return "pressure"
+    return "unknown"
+
+
+def detect_stall(stage: dict) -> dict:
+    """A stage stalled if it exited on a time failsafe with negligible weight gain."""
+    result = stage.get("exit_trigger_result") or {}
+    triggered = result.get("triggered") or {}
+    trig_type = triggered.get("type", "")
+    total = len(stage.get("exit_triggers") or [])
+    ed = stage.get("execution_data") or {}
+    gain = float(ed.get("weight_gain", 0) or 0)
+    klass = classify_trigger(_stage_control_mode(stage), trig_type, total)
+    stalled = klass["kind"] == "failsafe" and trig_type == "time" and gain < STALL_MIN_WEIGHT_GAIN_G
+    return {"stalled": stalled, "weight_gain": round(gain, 2)}
+
+
+def detect_channeling(execution_data: dict) -> dict:
+    """Flag likely channeling: pressure falls while flow rises within the stage."""
+    ed = execution_data or {}
+    p_drop = float(ed.get("start_pressure", 0) or 0) - float(ed.get("end_pressure", 0) or 0)
+    f_rise = float(ed.get("end_flow", 0) or 0) - float(ed.get("start_flow", 0) or 0)
+    channeling = p_drop >= CHANNELING_PRESSURE_DROP_BAR and f_rise >= CHANNELING_FLOW_RISE_MLS
+    return {"channeling": channeling, "pressure_drop": round(p_drop, 2), "flow_rise": round(f_rise, 2)}
+
+
+def _build_phases(local_analysis: dict) -> list[dict]:
+    """Group stages into pre-infusion / ramp / peak / decline by avg pressure shape."""
+    stages = [s for s in local_analysis.get("stage_analyses", []) if s.get("execution_data")]
+    phases: list[dict] = []
+    for s in stages:
+        ed = s["execution_data"]
+        avg_p = float(ed.get("avg_pressure", 0) or 0)
+        if avg_p < 3.0:
+            phase = "pre-infusion"
+        elif float(ed.get("end_pressure", 0) or 0) > float(ed.get("start_pressure", 0) or 0):
+            phase = "ramp"
+        elif float(ed.get("end_pressure", 0) or 0) < float(ed.get("start_pressure", 0) or 0):
+            phase = "decline"
+        else:
+            phase = "peak"
+        phases.append({
+            "stage_name": s.get("stage_name"),
+            "phase": phase,
+            "avg_pressure": ed.get("avg_pressure"),
+            "avg_flow": ed.get("avg_flow"),
+            "weight_gain": ed.get("weight_gain"),
+        })
+    return phases
+
+
+def _curve_adherence(stage: dict) -> dict | None:
+    """Compare measured avg vs the stage's first target dynamics point, if numeric."""
+    points = ((stage.get("profile_target") or {}) if isinstance(stage.get("profile_target"), dict) else {})
+    target = points.get("target_value")
+    ed = stage.get("execution_data") or {}
+    if target is None:
+        return None
+    mode = _stage_control_mode(stage)
+    measured = ed.get("avg_pressure") if mode == "pressure" else ed.get("avg_flow")
+    if measured is None:
+        return None
+    return {"target": target, "measured": measured, "delta": round(float(measured) - float(target), 2)}
+
+
+def build_shot_facts(local_analysis: dict) -> dict:
+    """Assemble the deterministic ShotFacts object consumed by the static view, the
+    LLM fact sheet, and the validator. Mirrors buildShotFacts() in shotFacts.ts."""
+    stages_out: list[dict] = []
+    for s in local_analysis.get("stage_analyses", []):
+        ed = s.get("execution_data")
+        if not ed:
+            stages_out.append({"stage_name": s.get("stage_name"), "reached": False})
+            continue
+        triggered = (s.get("exit_trigger_result") or {}).get("triggered") or {}
+        trig_type = triggered.get("type", "")
+        total = len(s.get("exit_triggers") or [])
+        stages_out.append({
+            "stage_name": s.get("stage_name"),
+            "reached": True,
+            "control_mode": _stage_control_mode(s),
+            "trigger_type": trig_type,
+            "trigger_class": classify_trigger(_stage_control_mode(s), trig_type, total),
+            "stall": detect_stall(s),
+            "channeling": detect_channeling(ed),
+            "curve_adherence": _curve_adherence(s),
+        })
+    wa = local_analysis.get("weight_analysis", {})
+    return {
+        "stages": stages_out,
+        "phases": _build_phases(local_analysis),
+        "weight": {
+            "actual": wa.get("actual"),
+            "target": wa.get("target"),
+            "deviation_pct": wa.get("deviation_percent"),
+        },
+        "total_time_s": local_analysis.get("overall_metrics", {}).get("total_time"),
+    }

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17555,3 +17555,48 @@ class TestCompassRules:
     def test_centered_taste_returns_no_changes(self):
         from services.compass_rules import compass_adjustments
         assert compass_adjustments(taste_x=0.0, taste_y=0.0) == []
+
+
+class TestAnalysisKnowledge:
+    def test_knowledge_constant_covers_trigger_classes(self):
+        from analysis_knowledge import ANALYSIS_KNOWLEDGE
+        assert "Targeted" in ANALYSIS_KNOWLEDGE
+        assert "Failsafe" in ANALYSIS_KNOWLEDGE
+        assert "channeling" in ANALYSIS_KNOWLEDGE.lower()
+
+    def test_fact_sheet_renders_stage_classification(self):
+        from analysis_knowledge import build_fact_sheet
+        facts = {
+            "stages": [{
+                "stage_name": "Infusion", "reached": True, "control_mode": "pressure",
+                "trigger_type": "weight",
+                "trigger_class": {"kind": "targeted", "label": "Targeted (yield reached)", "reason": "x"},
+                "stall": {"stalled": False, "weight_gain": 30.0},
+                "channeling": {"channeling": False, "pressure_drop": 0.1, "flow_rise": 0.1},
+                "curve_adherence": {"target": 9.0, "measured": 8.5, "delta": -0.5},
+            }],
+            "phases": [],
+            "weight": {"actual": 36.0, "target": 36.0, "deviation_pct": 0.0},
+            "total_time_s": 30.0,
+        }
+        sheet = build_fact_sheet(facts)
+        assert "Infusion" in sheet
+        assert "Targeted (yield reached)" in sheet
+        assert "36" in sheet
+
+    def test_fact_sheet_flags_stall_and_channeling(self):
+        from analysis_knowledge import build_fact_sheet
+        facts = {
+            "stages": [{
+                "stage_name": "Decline", "reached": True, "control_mode": "pressure",
+                "trigger_type": "time",
+                "trigger_class": {"kind": "failsafe", "label": "Failsafe (timeout limit)", "reason": "x"},
+                "stall": {"stalled": True, "weight_gain": 0.2},
+                "channeling": {"channeling": True, "pressure_drop": 3.0, "flow_rise": 2.0},
+                "curve_adherence": None,
+            }],
+            "phases": [], "weight": {}, "total_time_s": 25.0,
+        }
+        sheet = build_fact_sheet(facts).lower()
+        assert "stall" in sheet
+        assert "channel" in sheet

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17419,3 +17419,68 @@ class TestShotFactsClassify:
         from services.shot_facts import classify_trigger
         r = classify_trigger("power", "weird", total_triggers=1)
         assert r["kind"] == "unknown"
+
+
+class TestShotFacts:
+    def _stage(self, **kw):
+        base = {
+            "stage_name": "Infusion",
+            "stage_type": "flow",
+            "exit_triggers": [],
+            "execution_data": {
+                "duration": 10.0, "weight_gain": 2.0, "end_weight": 8.0,
+                "start_pressure": 1.0, "end_pressure": 6.0, "avg_pressure": 4.0,
+                "max_pressure": 6.5, "min_pressure": 1.0,
+                "start_flow": 4.0, "end_flow": 0.5, "avg_flow": 2.0, "max_flow": 4.5,
+            },
+            "exit_trigger_result": {"triggered": {"type": "time"}},
+        }
+        base.update(kw)
+        return base
+
+    def test_stall_detected_on_time_failsafe_with_low_gain(self):
+        from services.shot_facts import detect_stall
+        stage = self._stage(
+            stage_type="pressure",
+            exit_triggers=[{"type": "flow"}, {"type": "time"}],
+            exit_trigger_result={"triggered": {"type": "time"}},
+            execution_data={**self._stage()["execution_data"], "weight_gain": 0.3},
+        )
+        assert detect_stall(stage)["stalled"] is True
+
+    def test_no_stall_when_weight_trigger(self):
+        from services.shot_facts import detect_stall
+        stage = self._stage(exit_trigger_result={"triggered": {"type": "weight"}})
+        assert detect_stall(stage)["stalled"] is False
+
+    def test_channeling_flag_on_pressure_drop_with_flow_rise(self):
+        from services.shot_facts import detect_channeling
+        ed = {**self._stage()["execution_data"],
+              "start_pressure": 8.0, "end_pressure": 3.0,
+              "start_flow": 1.0, "end_flow": 5.0}
+        assert detect_channeling(ed)["channeling"] is True
+
+    def test_no_channeling_on_stable_stage(self):
+        from services.shot_facts import detect_channeling
+        ed = {**self._stage()["execution_data"],
+              "start_pressure": 6.0, "end_pressure": 6.2,
+              "start_flow": 2.0, "end_flow": 2.1}
+        assert detect_channeling(ed)["channeling"] is False
+
+    def test_build_shot_facts_classifies_each_stage(self):
+        from services.shot_facts import build_shot_facts
+        local = {
+            "stage_analyses": [
+                self._stage(
+                    stage_type="pressure",
+                    exit_triggers=[{"type": "weight"}],
+                    exit_trigger_result={"triggered": {"type": "weight"}},
+                ),
+            ],
+            "weight_analysis": {"actual": 36.0, "target": 36.0, "deviation_percent": 0.0},
+            "overall_metrics": {"total_time": 30.0},
+        }
+        facts = build_shot_facts(local)
+        assert len(facts["stages"]) == 1
+        assert facts["stages"][0]["trigger_class"]["kind"] == "targeted"
+        assert "phases" in facts

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17484,3 +17484,46 @@ class TestShotFacts:
         assert len(facts["stages"]) == 1
         assert facts["stages"][0]["trigger_class"]["kind"] == "targeted"
         assert "phases" in facts
+
+
+class TestLocalAnalysisIncludesFacts:
+    def test_local_analysis_attaches_shot_facts(self):
+        from services.analysis_service import _perform_local_shot_analysis
+
+        shot_data = {
+            "data": [
+                {"time": 0, "shot": {"weight": 0, "pressure": 2.0, "flow": 0.5}, "status": "Bloom"},
+                {"time": 5000, "shot": {"weight": 2.0, "pressure": 2.0, "flow": 0.5}, "status": "Bloom"},
+                {"time": 6000, "shot": {"weight": 5.0, "pressure": 9.0, "flow": 2.5}, "status": "Main"},
+                {"time": 25000, "shot": {"weight": 36.0, "pressure": 9.0, "flow": 2.5}, "status": "Main"},
+            ]
+        }
+
+        profile_data = {
+            "name": "Test Profile",
+            "final_weight": 36.0,
+            "stages": [
+                {
+                    "name": "Bloom",
+                    "key": "bloom",
+                    "type": "pressure",
+                    "dynamics_points": [[0, 2.0]],
+                    "dynamics_over": "time",
+                    "exit_triggers": [{"type": "time", "value": 5, "comparison": ">="}],
+                },
+                {
+                    "name": "Main",
+                    "key": "main",
+                    "type": "pressure",
+                    "dynamics_points": [[0, 9.0]],
+                    "dynamics_over": "time",
+                    "exit_triggers": [{"type": "weight", "value": 36, "comparison": ">="}],
+                },
+            ],
+            "variables": [],
+        }
+
+        result = _perform_local_shot_analysis(shot_data, profile_data)
+
+        assert "shot_facts" in result
+        assert "stages" in result["shot_facts"]

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17370,3 +17370,52 @@ class TestAITags:
         assert resp.status_code == 200
         assert history[0]["ai_tags"] == ["Chocolate", "Creamy"]
         assert history[0]["reply"] == "A fresh AI description."
+
+
+class TestShotFactsClassify:
+    """#423 Targeted vs Failsafe trigger classification."""
+
+    def test_weight_is_always_targeted(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("pressure", "weight", total_triggers=2)
+        assert r["kind"] == "targeted"
+        assert "yield" in r["label"].lower()
+
+    def test_time_only_trigger_is_planned_duration(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("flow", "time", total_triggers=1)
+        assert r["kind"] == "targeted"
+        assert "planned" in r["label"].lower()
+
+    def test_time_with_other_triggers_is_failsafe_timeout(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("flow", "time", total_triggers=2)
+        assert r["kind"] == "failsafe"
+        assert "timeout" in r["label"].lower()
+
+    def test_flow_control_pressure_trigger_is_puck_resistance(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("flow", "pressure", total_triggers=2)
+        assert r["kind"] == "targeted"
+        assert "resistance" in r["label"].lower()
+
+    def test_pressure_control_flow_only_trigger_is_planned_transition(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("pressure", "flow", total_triggers=1)
+        assert r["kind"] == "targeted"
+
+    def test_pressure_control_flow_with_others_is_failsafe_channeling(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("pressure", "flow", total_triggers=2)
+        assert r["kind"] == "failsafe"
+        assert "channel" in r["label"].lower() or "chok" in r["label"].lower()
+
+    def test_pressure_control_pressure_trigger_is_threshold(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("pressure", "pressure", total_triggers=1)
+        assert r["kind"] == "targeted"
+
+    def test_unknown_combo_returns_unknown(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("power", "weird", total_triggers=1)
+        assert r["kind"] == "unknown"

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17494,6 +17494,55 @@ class TestShotFacts:
         }
         assert build_shot_facts(local)["total_time_s"] == 28.5
 
+    def test_curve_adherence_uses_profile_target_value(self):
+        from services.shot_facts import build_shot_facts
+        local = {
+            "stage_analyses": [
+                self._stage(
+                    stage_type="pressure",
+                    profile_target_value=9.0,
+                    execution_data={**self._stage()["execution_data"], "avg_pressure": 8.5},
+                ),
+            ],
+            "weight_analysis": {},
+            "shot_summary": {"total_time": 30.0},
+        }
+        ca = build_shot_facts(local)["stages"][0]["curve_adherence"]
+        assert ca is not None
+        assert ca["target"] == 9.0
+        assert ca["measured"] == 8.5
+        assert ca["delta"] == -0.5
+
+    def test_curve_adherence_none_without_target(self):
+        from services.shot_facts import build_shot_facts
+        local = {
+            "stage_analyses": [self._stage(stage_type="pressure")],
+            "weight_analysis": {},
+            "shot_summary": {"total_time": 30.0},
+        }
+        assert build_shot_facts(local)["stages"][0]["curve_adherence"] is None
+
+
+class TestMeanDynamicsTarget:
+    def test_mean_of_pressure_setpoints(self):
+        from services.analysis_service import _mean_dynamics_target
+        stage = {"type": "pressure", "dynamics_points": [[0, 2.0], [10, 8.0]]}
+        assert _mean_dynamics_target(stage) == 5.0
+
+    def test_resolves_variable_references(self):
+        from services.analysis_service import _mean_dynamics_target
+        stage = {"type": "flow", "dynamics_points": [[0, "$f"], [5, 4.0]]}
+        variables = [{"key": "f", "name": "Flow", "value": 2.0}]
+        assert _mean_dynamics_target(stage, variables) == 3.0
+
+    def test_none_for_non_pressure_flow_stage(self):
+        from services.analysis_service import _mean_dynamics_target
+        assert _mean_dynamics_target({"type": "power", "dynamics_points": [[0, 5]]}) is None
+
+    def test_none_when_no_numeric_points(self):
+        from services.analysis_service import _mean_dynamics_target
+        assert _mean_dynamics_target({"type": "pressure", "dynamics_points": []}) is None
+
 
 class TestLocalAnalysisIncludesFacts:
     def test_local_analysis_attaches_shot_facts(self):

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17707,3 +17707,22 @@ class TestAnalysisValidator:
         from services.analysis_validator import validate_against_facts
         text = "- Severe channeling caused the pressure to collapse."
         assert "unsupported-channeling" in validate_against_facts(text, self._facts_targeted_weight())["issues"]
+
+
+class TestAnalysisStructure:
+    def test_schema_lists_core_sections(self):
+        from analysis_schema import REQUIRED_ANALYSIS_SECTIONS
+        assert "Shot Performance" in REQUIRED_ANALYSIS_SECTIONS
+        assert len(REQUIRED_ANALYSIS_SECTIONS) >= 5
+
+    def test_check_structure_flags_missing_sections(self):
+        from services.analysis_validator import check_structure
+        r = check_structure("## 1. Shot Performance\n- ok")
+        assert r["valid"] is False
+        assert "missing-sections" in r["issues"]
+
+    def test_check_structure_accepts_full_text(self):
+        from analysis_schema import REQUIRED_ANALYSIS_SECTIONS
+        from services.analysis_validator import check_structure
+        text = "\n".join(f"## {i+1}. {s}\n- content" for i, s in enumerate(REQUIRED_ANALYSIS_SECTIONS))
+        assert check_structure(text)["valid"] is True

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17726,3 +17726,13 @@ class TestAnalysisStructure:
         from services.analysis_validator import check_structure
         text = "\n".join(f"## {i+1}. {s}\n- content" for i, s in enumerate(REQUIRED_ANALYSIS_SECTIONS))
         assert check_structure(text)["valid"] is True
+
+
+class TestAnalysisCoverageMatrix:
+    def test_server_exposes_all_analysis_checks(self):
+        from services import analysis_validator as v
+        assert callable(v.validate_against_facts)
+        assert callable(v.check_structure)
+        from analysis_knowledge import build_fact_sheet, ANALYSIS_KNOWLEDGE  # noqa: F401
+        from services.shot_facts import build_shot_facts, classify_trigger  # noqa: F401
+        from services.compass_rules import compass_adjustments  # noqa: F401

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17485,6 +17485,15 @@ class TestShotFacts:
         assert facts["stages"][0]["trigger_class"]["kind"] == "targeted"
         assert "phases" in facts
 
+    def test_total_time_falls_back_to_shot_summary(self):
+        from services.shot_facts import build_shot_facts
+        local = {
+            "stage_analyses": [],
+            "weight_analysis": {},
+            "shot_summary": {"total_time": 28.5},
+        }
+        assert build_shot_facts(local)["total_time_s"] == 28.5
+
 
 class TestLocalAnalysisIncludesFacts:
     def test_local_analysis_attaches_shot_facts(self):

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17600,3 +17600,77 @@ class TestAnalysisKnowledge:
         sheet = build_fact_sheet(facts).lower()
         assert "stall" in sheet
         assert "channel" in sheet
+
+
+class TestAnalysisPromptContent:
+    """The analyze-llm prompt must carry ANALYSIS_KNOWLEDGE, the fact sheet, and the few-shot."""
+
+    @patch("api.routes.shots.fetch_shot_data", new_callable=AsyncMock)
+    @patch("api.routes.shots.async_get_profile", new_callable=AsyncMock)
+    @patch("api.routes.shots.async_list_profiles", new_callable=AsyncMock)
+    @patch("api.routes.shots.get_vision_model")
+    @patch("api.routes.shots._perform_local_shot_analysis")
+    def test_prompt_includes_knowledge_factsheet_fewshot(
+        self,
+        mock_local_analysis,
+        mock_get_model,
+        mock_list_profiles,
+        mock_get_profile,
+        mock_fetch_shot,
+        client,
+    ):
+        mock_fetch_shot.return_value = {
+            "profile_name": "Test",
+            "time": 1705320000,
+            "data": [{"time": 25000, "shot": {"weight": 36.0}}],
+        }
+
+        partial = type("P", (), {})()
+        partial.name = "Test"
+        partial.id = "p-123"
+        partial.error = None
+        mock_list_profiles.return_value = [partial]
+
+        full = type("F", (), {})()
+        full.name = "Test"
+        full.temperature = 93.0
+        full.final_weight = 36.0
+        full.variables = []
+        full.stages = []
+        full.error = None
+        mock_get_profile.return_value = full
+
+        mock_local_analysis.return_value = {
+            "shot_summary": {"final_weight": 36.0, "total_time": 28.0},
+            "weight_analysis": {"actual": 36.0, "target": 36.0, "deviation_percent": 0.0},
+            "stage_analyses": [],
+            "shot_facts": {
+                "stages": [],
+                "phases": [],
+                "weight": {"actual": 36.0, "target": 36.0, "deviation_pct": 0.0},
+                "total_time_s": 28.0,
+            },
+        }
+
+        mock_model = MagicMock()
+        mock_model.async_generate_content = AsyncMock(
+            return_value=MagicMock(
+                text="## 1. Shot Performance\n**What Happened:**\n- ok\n**Assessment:** Good"
+            )
+        )
+        mock_get_model.return_value = mock_model
+
+        resp = client.post(
+            "/api/shots/analyze-llm",
+            data={
+                "profile_name": "Test",
+                "shot_date": "2024-01-15",
+                "shot_filename": "shot.json",
+                "force_refresh": "true",
+            },
+        )
+        assert resp.status_code == 200
+        prompt = mock_model.async_generate_content.call_args[0][0]
+        assert "EXIT TRIGGER CLASSIFICATION" in prompt          # ANALYSIS_KNOWLEDGE
+        assert "Deterministic Shot Facts" in prompt              # fact sheet
+        assert "Worked Example" in prompt                        # few-shot

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17536,3 +17536,22 @@ class TestLocalAnalysisIncludesFacts:
 
         assert "shot_facts" in result
         assert "stages" in result["shot_facts"]
+
+
+class TestCompassRules:
+    def test_sour_and_weak_suggests_finer_and_hotter(self):
+        from services.compass_rules import compass_adjustments
+        adj = compass_adjustments(taste_x=-0.8, taste_y=-0.6)
+        kinds = {a["kind"] for a in adj}
+        assert "grind_finer" in kinds
+        assert any(a["kind"] in ("temp_up", "ratio_up", "dose_up") for a in adj)
+
+    def test_bitter_and_strong_suggests_coarser_and_cooler(self):
+        from services.compass_rules import compass_adjustments
+        adj = compass_adjustments(taste_x=0.8, taste_y=0.7)
+        kinds = {a["kind"] for a in adj}
+        assert "grind_coarser" in kinds
+
+    def test_centered_taste_returns_no_changes(self):
+        from services.compass_rules import compass_adjustments
+        assert compass_adjustments(taste_x=0.0, taste_y=0.0) == []

--- a/apps/server/test_main.py
+++ b/apps/server/test_main.py
@@ -17674,3 +17674,36 @@ class TestAnalysisPromptContent:
         assert "EXIT TRIGGER CLASSIFICATION" in prompt          # ANALYSIS_KNOWLEDGE
         assert "Deterministic Shot Facts" in prompt              # fact sheet
         assert "Worked Example" in prompt                        # few-shot
+
+
+class TestAnalysisValidator:
+    def _facts_targeted_weight(self):
+        return {
+            "stages": [{
+                "stage_name": "Hold", "reached": True, "control_mode": "pressure",
+                "trigger_type": "weight",
+                "trigger_class": {"kind": "targeted", "label": "Targeted (yield reached)", "reason": ""},
+                "stall": {"stalled": False, "weight_gain": 30.0},
+                "channeling": {"channeling": False, "pressure_drop": 0.0, "flow_rise": 0.0},
+                "curve_adherence": None,
+            }],
+            "phases": [], "weight": {"actual": 36.0, "target": 36.0, "deviation_pct": 0.0},
+            "total_time_s": 28.0,
+        }
+
+    def test_flags_targeted_exit_called_early_termination(self):
+        from services.analysis_validator import validate_against_facts
+        text = "- The hold stage terminated early before reaching its goal."
+        r = validate_against_facts(text, self._facts_targeted_weight())
+        assert r["valid"] is False
+        assert "mischaracterized-targeted-exit" in r["issues"]
+
+    def test_accepts_success_framing(self):
+        from services.analysis_validator import validate_against_facts
+        text = "- The hold stage ended exactly on the weight target, a correct finish."
+        assert validate_against_facts(text, self._facts_targeted_weight())["valid"] is True
+
+    def test_flags_unsupported_channeling(self):
+        from services.analysis_validator import validate_against_facts
+        text = "- Severe channeling caused the pressure to collapse."
+        assert "unsupported-channeling" in validate_against_facts(text, self._facts_targeted_weight())["issues"]

--- a/apps/web/public/locales/de/translation.json
+++ b/apps/web/public/locales/de/translation.json
@@ -1845,5 +1845,13 @@
     "selectImage": "Bild auswählen",
     "regenerateSlot": "Neu generieren",
     "generating": "Wird generiert..."
+  },
+  "analysis": {
+    "facts": {
+      "title": "Phasensignale",
+      "stalled": "Stehengeblieben",
+      "channeling": "Mögliches Channeling",
+      "curveDelta": "Kurve Δ {{delta}}"
+    }
   }
 }

--- a/apps/web/public/locales/de/translation.json
+++ b/apps/web/public/locales/de/translation.json
@@ -1852,6 +1852,12 @@
       "stalled": "Stehengeblieben",
       "channeling": "Mögliches Channeling",
       "curveDelta": "Kurve Δ {{delta}}"
+    },
+    "taste": {
+      "gateTitle": "Mit Geschmack verfeinern (optional)",
+      "gateBody": "Teile mit, wie der Shot geschmeckt hat, für geschmacksbewusste Empfehlungen.",
+      "skip": "Überspringen",
+      "analyzeWithTaste": "Mit Geschmack analysieren"
     }
   }
 }

--- a/apps/web/public/locales/de/translation.json
+++ b/apps/web/public/locales/de/translation.json
@@ -1851,7 +1851,8 @@
       "title": "Phasensignale",
       "stalled": "Stehengeblieben",
       "channeling": "Mögliches Channeling",
-      "curveDelta": "Kurve Δ {{delta}}"
+      "curveDelta": "Kurve Δ {{delta}}",
+      "adjustmentsTitle": "Vorgeschlagene Anpassungen"
     },
     "taste": {
       "gateTitle": "Mit Geschmack verfeinern (optional)",

--- a/apps/web/public/locales/en/translation.json
+++ b/apps/web/public/locales/en/translation.json
@@ -1852,6 +1852,12 @@
       "stalled": "Stalled",
       "channeling": "Possible channeling",
       "curveDelta": "Curve Δ {{delta}}"
+    },
+    "taste": {
+      "gateTitle": "Refine with taste (optional)",
+      "gateBody": "Tell the analysis how this shot tasted for sharper, taste-aware recommendations.",
+      "skip": "Skip",
+      "analyzeWithTaste": "Analyze with taste"
     }
   }
 }

--- a/apps/web/public/locales/en/translation.json
+++ b/apps/web/public/locales/en/translation.json
@@ -1845,5 +1845,13 @@
     "selectImage": "Select an image",
     "regenerateSlot": "Regenerate",
     "generating": "Generating..."
+  },
+  "analysis": {
+    "facts": {
+      "title": "Stage signals",
+      "stalled": "Stalled",
+      "channeling": "Possible channeling",
+      "curveDelta": "Curve Δ {{delta}}"
+    }
   }
 }

--- a/apps/web/public/locales/en/translation.json
+++ b/apps/web/public/locales/en/translation.json
@@ -1851,7 +1851,8 @@
       "title": "Stage signals",
       "stalled": "Stalled",
       "channeling": "Possible channeling",
-      "curveDelta": "Curve Δ {{delta}}"
+      "curveDelta": "Curve Δ {{delta}}",
+      "adjustmentsTitle": "Suggested adjustments"
     },
     "taste": {
       "gateTitle": "Refine with taste (optional)",

--- a/apps/web/public/locales/es/translation.json
+++ b/apps/web/public/locales/es/translation.json
@@ -1851,7 +1851,8 @@
       "title": "Señales de fase",
       "stalled": "Estancado",
       "channeling": "Posible canalización",
-      "curveDelta": "Curva Δ {{delta}}"
+      "curveDelta": "Curva Δ {{delta}}",
+      "adjustmentsTitle": "Ajustes sugeridos"
     },
     "taste": {
       "gateTitle": "Refinar con el sabor (opcional)",

--- a/apps/web/public/locales/es/translation.json
+++ b/apps/web/public/locales/es/translation.json
@@ -1845,5 +1845,13 @@
     "selectImage": "Seleccionar una imagen",
     "regenerateSlot": "Regenerar",
     "generating": "Generando..."
+  },
+  "analysis": {
+    "facts": {
+      "title": "Señales de fase",
+      "stalled": "Estancado",
+      "channeling": "Posible canalización",
+      "curveDelta": "Curva Δ {{delta}}"
+    }
   }
 }

--- a/apps/web/public/locales/es/translation.json
+++ b/apps/web/public/locales/es/translation.json
@@ -1852,6 +1852,12 @@
       "stalled": "Estancado",
       "channeling": "Posible canalización",
       "curveDelta": "Curva Δ {{delta}}"
+    },
+    "taste": {
+      "gateTitle": "Refinar con el sabor (opcional)",
+      "gateBody": "Indica a qué supo este shot para recomendaciones más precisas.",
+      "skip": "Omitir",
+      "analyzeWithTaste": "Analizar con el sabor"
     }
   }
 }

--- a/apps/web/public/locales/fr/translation.json
+++ b/apps/web/public/locales/fr/translation.json
@@ -1851,7 +1851,8 @@
       "title": "Signaux de phase",
       "stalled": "Bloqué",
       "channeling": "Chenalisation possible",
-      "curveDelta": "Courbe Δ {{delta}}"
+      "curveDelta": "Courbe Δ {{delta}}",
+      "adjustmentsTitle": "Ajustements suggérés"
     },
     "taste": {
       "gateTitle": "Affiner avec le goût (facultatif)",

--- a/apps/web/public/locales/fr/translation.json
+++ b/apps/web/public/locales/fr/translation.json
@@ -1852,6 +1852,12 @@
       "stalled": "Bloqué",
       "channeling": "Chenalisation possible",
       "curveDelta": "Courbe Δ {{delta}}"
+    },
+    "taste": {
+      "gateTitle": "Affiner avec le goût (facultatif)",
+      "gateBody": "Indiquez le goût de cette extraction pour des recommandations plus fines.",
+      "skip": "Ignorer",
+      "analyzeWithTaste": "Analyser avec le goût"
     }
   }
 }

--- a/apps/web/public/locales/fr/translation.json
+++ b/apps/web/public/locales/fr/translation.json
@@ -1845,5 +1845,13 @@
     "selectImage": "Sélectionner une image",
     "regenerateSlot": "Régénérer",
     "generating": "Génération..."
+  },
+  "analysis": {
+    "facts": {
+      "title": "Signaux de phase",
+      "stalled": "Bloqué",
+      "channeling": "Chenalisation possible",
+      "curveDelta": "Courbe Δ {{delta}}"
+    }
   }
 }

--- a/apps/web/public/locales/it/translation.json
+++ b/apps/web/public/locales/it/translation.json
@@ -1852,6 +1852,12 @@
       "stalled": "Bloccato",
       "channeling": "Possibile canalizzazione",
       "curveDelta": "Curva Δ {{delta}}"
+    },
+    "taste": {
+      "gateTitle": "Affina con il gusto (facoltativo)",
+      "gateBody": "Indica com'era il gusto per consigli più mirati.",
+      "skip": "Salta",
+      "analyzeWithTaste": "Analizza con il gusto"
     }
   }
 }

--- a/apps/web/public/locales/it/translation.json
+++ b/apps/web/public/locales/it/translation.json
@@ -1845,5 +1845,13 @@
     "selectImage": "Seleziona un'immagine",
     "regenerateSlot": "Rigenera",
     "generating": "Generazione..."
+  },
+  "analysis": {
+    "facts": {
+      "title": "Segnali di fase",
+      "stalled": "Bloccato",
+      "channeling": "Possibile canalizzazione",
+      "curveDelta": "Curva Δ {{delta}}"
+    }
   }
 }

--- a/apps/web/public/locales/it/translation.json
+++ b/apps/web/public/locales/it/translation.json
@@ -1851,7 +1851,8 @@
       "title": "Segnali di fase",
       "stalled": "Bloccato",
       "channeling": "Possibile canalizzazione",
-      "curveDelta": "Curva Δ {{delta}}"
+      "curveDelta": "Curva Δ {{delta}}",
+      "adjustmentsTitle": "Regolazioni suggerite"
     },
     "taste": {
       "gateTitle": "Affina con il gusto (facoltativo)",

--- a/apps/web/public/locales/sv/translation.json
+++ b/apps/web/public/locales/sv/translation.json
@@ -1852,6 +1852,12 @@
       "stalled": "Avstannade",
       "channeling": "Möjlig kanalbildning",
       "curveDelta": "Kurva Δ {{delta}}"
+    },
+    "taste": {
+      "gateTitle": "Förfina med smak (valfritt)",
+      "gateBody": "Berätta hur koppen smakade för smakmedvetna rekommendationer.",
+      "skip": "Hoppa över",
+      "analyzeWithTaste": "Analysera med smak"
     }
   }
 }

--- a/apps/web/public/locales/sv/translation.json
+++ b/apps/web/public/locales/sv/translation.json
@@ -1851,7 +1851,8 @@
       "title": "Stegsignaler",
       "stalled": "Avstannade",
       "channeling": "Möjlig kanalbildning",
-      "curveDelta": "Kurva Δ {{delta}}"
+      "curveDelta": "Kurva Δ {{delta}}",
+      "adjustmentsTitle": "Föreslagna justeringar"
     },
     "taste": {
       "gateTitle": "Förfina med smak (valfritt)",

--- a/apps/web/public/locales/sv/translation.json
+++ b/apps/web/public/locales/sv/translation.json
@@ -1845,5 +1845,13 @@
     "selectImage": "Välj en bild",
     "regenerateSlot": "Generera om",
     "generating": "Genererar..."
+  },
+  "analysis": {
+    "facts": {
+      "title": "Stegsignaler",
+      "stalled": "Avstannade",
+      "channeling": "Möjlig kanalbildning",
+      "curveDelta": "Kurva Δ {{delta}}"
+    }
   }
 }

--- a/apps/web/src/components/ShotHistoryView/AnalysisTasteGate.test.tsx
+++ b/apps/web/src/components/ShotHistoryView/AnalysisTasteGate.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AnalysisTasteGate } from './AnalysisTasteGate'
+import { DEFAULT_TASTE_DATA } from '../TasteCompassInput'
+
+describe('AnalysisTasteGate (U1)', () => {
+  it('calls onSkip when the user skips', () => {
+    const onSkip = vi.fn()
+    render(<AnalysisTasteGate onAnalyze={vi.fn()} onSkip={onSkip} />)
+    fireEvent.click(screen.getByTestId('taste-gate-skip'))
+    expect(onSkip).toHaveBeenCalledTimes(1)
+  })
+  it('calls onAnalyze with current taste data', () => {
+    const onAnalyze = vi.fn()
+    render(<AnalysisTasteGate onAnalyze={onAnalyze} onSkip={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('taste-gate-analyze'))
+    expect(onAnalyze).toHaveBeenCalledWith(DEFAULT_TASTE_DATA)
+  })
+})

--- a/apps/web/src/components/ShotHistoryView/AnalysisTasteGate.tsx
+++ b/apps/web/src/components/ShotHistoryView/AnalysisTasteGate.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '../ui/button'
+import { TasteCompassInput, DEFAULT_TASTE_DATA, type TasteData } from '../TasteCompassInput'
+
+interface Props {
+  onAnalyze: (taste: TasteData) => void
+  onSkip: () => void
+  initialTaste?: TasteData
+}
+
+export function AnalysisTasteGate({ onAnalyze, onSkip, initialTaste }: Props) {
+  const { t } = useTranslation()
+  const [taste, setTaste] = useState<TasteData>(initialTaste ?? DEFAULT_TASTE_DATA)
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-4">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-foreground">{t('analysis.taste.gateTitle')}</h3>
+        <p className="text-xs text-muted-foreground">{t('analysis.taste.gateBody')}</p>
+      </div>
+      <TasteCompassInput value={taste} onChange={setTaste} />
+      <div className="flex gap-2 justify-end">
+        <Button variant="ghost" data-testid="taste-gate-skip" onClick={onSkip}>
+          {t('analysis.taste.skip')}
+        </Button>
+        <Button data-testid="taste-gate-analyze" onClick={() => onAnalyze(taste)}>
+          {t('analysis.taste.analyzeWithTaste')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ShotHistoryView/ShotDetail.tsx
+++ b/apps/web/src/components/ShotHistoryView/ShotDetail.tsx
@@ -60,6 +60,7 @@ import {
 } from './shotDataTransforms'
 import { useReplayAnimation } from './useReplayAnimation'
 import { ReplayScrubber } from './ReplayScrubber'
+import { ShotFactsPanel } from './ShotFactsPanel'
 
 // ---------------------------------------------------------------------------
 // Comparison StatCard — extracted from inline IIFE for clarity
@@ -1029,6 +1030,7 @@ export function ShotDetail({
                     {analysisResult && (
                       <div className="space-y-4">
                         <div ref={analysisCardRef} className="space-y-4">
+                          {analysisResult.shot_facts && <ShotFactsPanel facts={analysisResult.shot_facts} />}
                           {/* Shot Summary Card */}
                           <div className="p-4 bg-gradient-to-br from-primary/10 via-secondary/30 to-secondary/20 rounded-xl border border-primary/20">
                             <div className="flex items-center gap-2 mb-3">

--- a/apps/web/src/components/ShotHistoryView/ShotDetail.tsx
+++ b/apps/web/src/components/ShotHistoryView/ShotDetail.tsx
@@ -61,6 +61,9 @@ import {
 import { useReplayAnimation } from './useReplayAnimation'
 import { ReplayScrubber } from './ReplayScrubber'
 import { ShotFactsPanel } from './ShotFactsPanel'
+import { AnalysisTasteGate } from './AnalysisTasteGate'
+import { saveShotTaste, loadShotTaste, type StoredTaste } from '../../lib/shotTasteStore'
+import type { TasteData } from '../TasteCompassInput'
 
 // ---------------------------------------------------------------------------
 // Comparison StatCard — extracted from inline IIFE for clarity
@@ -165,6 +168,8 @@ export function ShotDetail({
   const [llmAnalysisError, setLlmAnalysisError] = useState<string | null>(null)
   const [showLlmView, setShowLlmView] = useState(false)
   const [isLlmCached, setIsLlmCached] = useState(false)
+  const [showTasteGate, setShowTasteGate] = useState(false)
+  const [shotTaste, setShotTaste] = useState<StoredTaste | null>(null)
 
   useScrollToTop([showLlmView])
 
@@ -287,8 +292,13 @@ export function ShotDetail({
     return undefined
   }, [selectedShot, shotData]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- load persisted taste on shot change
+    if (selectedShot) setShotTaste(loadShotTaste(profileName, selectedShot.date, selectedShot.filename))
+  }, [selectedShot, profileName])
+
   // ---- LLM analysis -------------------------------------------------------
-  const handleLlmAnalysis = async () => {
+  const handleLlmAnalysis = async (taste: StoredTaste | null) => {
     if (!selectedShot || !shotData) return
     setShowLlmView(true)
     setIsLlmAnalyzing(true)
@@ -302,6 +312,11 @@ export function ShotDetail({
       const profileData = shotData.profile as { description?: string; notes?: string } | undefined
       const profileDesc = profileData?.description || profileData?.notes
       if (profileDesc) formData.append('profile_description', profileDesc)
+      if (taste) {
+        formData.append('taste_x', String(taste.x))
+        formData.append('taste_y', String(taste.y))
+        if (taste.descriptors.length) formData.append('taste_descriptors', taste.descriptors.join(','))
+      }
       const response = await fetch(`${serverUrl}/api/shots/analyze-llm`, { method: 'POST', body: formData })
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({ message: 'LLM Analysis failed' }))
@@ -361,6 +376,11 @@ export function ShotDetail({
       const profileData = shotData.profile as { description?: string; notes?: string } | undefined
       const profileDesc = profileData?.description || profileData?.notes
       if (profileDesc) formData.append('profile_description', profileDesc)
+      if (shotTaste) {
+        formData.append('taste_x', String(shotTaste.x))
+        formData.append('taste_y', String(shotTaste.y))
+        if (shotTaste.descriptors.length) formData.append('taste_descriptors', shotTaste.descriptors.join(','))
+      }
       const response = await fetch(`${serverUrl}/api/shots/analyze-llm`, { method: 'POST', body: formData })
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({ message: 'LLM Analysis failed' }))
@@ -1030,7 +1050,7 @@ export function ShotDetail({
                     {analysisResult && (
                       <div className="space-y-4">
                         <div ref={analysisCardRef} className="space-y-4">
-                          {analysisResult.shot_facts && <ShotFactsPanel facts={analysisResult.shot_facts} />}
+                          {analysisResult.shot_facts && <ShotFactsPanel facts={analysisResult.shot_facts} taste={shotTaste} />}
                           {/* Shot Summary Card */}
                           <div className="p-4 bg-gradient-to-br from-primary/10 via-secondary/30 to-secondary/20 rounded-xl border border-primary/20">
                             <div className="flex items-center gap-2 mb-3">
@@ -1440,11 +1460,25 @@ export function ShotDetail({
                               {t('shotHistory.viewAiAnalysis')}
                             </Button>
                           ) : (
-                            <Button variant="default" size="sm" onClick={handleLlmAnalysis} disabled={isLlmAnalyzing || !aiConfigured} className="gap-1.5 w-full ai-shimmer-button border-0">
+                            <Button variant="default" size="sm" onClick={() => setShowTasteGate(true)} disabled={isLlmAnalyzing || !aiConfigured} className="gap-1.5 w-full ai-shimmer-button border-0">
                               <Brain size={14} weight="fill" />
                               {t('shotHistory.getAiAnalysis')}
                             </Button>
                           ))}
+
+                          {showTasteGate && (
+                            <AnalysisTasteGate
+                              initialTaste={shotTaste ? { x: shotTaste.x, y: shotTaste.y, descriptors: shotTaste.descriptors } as TasteData : undefined}
+                              onSkip={() => { setShowTasteGate(false); handleLlmAnalysis(null) }}
+                              onAnalyze={(taste) => {
+                                const stored: StoredTaste = { x: taste.x, y: taste.y, descriptors: taste.descriptors ?? [] }
+                                setShotTaste(stored)
+                                if (selectedShot) saveShotTaste(profileName, selectedShot.date, selectedShot.filename, stored)
+                                setShowTasteGate(false)
+                                handleLlmAnalysis(stored)
+                              }}
+                            />
+                          )}
 
                           {!aiConfigured && !hideAiWhenUnavailable && (
                             <p className="text-[11px] text-muted-foreground text-center">{t('shotHistory.aiUnavailable')}</p>

--- a/apps/web/src/components/ShotHistoryView/ShotDetail.tsx
+++ b/apps/web/src/components/ShotHistoryView/ShotDetail.tsx
@@ -170,6 +170,7 @@ export function ShotDetail({
   const [isLlmCached, setIsLlmCached] = useState(false)
   const [showTasteGate, setShowTasteGate] = useState(false)
   const [shotTaste, setShotTaste] = useState<StoredTaste | null>(null)
+  const [lastUsedTaste, setLastUsedTaste] = useState<StoredTaste | null>(null)
 
   useScrollToTop([showLlmView])
 
@@ -293,13 +294,16 @@ export function ShotDetail({
   }, [selectedShot, shotData]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- load persisted taste on shot change
-    if (selectedShot) setShotTaste(loadShotTaste(profileName, selectedShot.date, selectedShot.filename))
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset taste state on shot change
+    setShowTasteGate(false)
+    setLastUsedTaste(null)
+    setShotTaste(selectedShot ? loadShotTaste(profileName, selectedShot.date, selectedShot.filename) : null)
   }, [selectedShot, profileName])
 
   // ---- LLM analysis -------------------------------------------------------
   const handleLlmAnalysis = async (taste: StoredTaste | null) => {
     if (!selectedShot || !shotData) return
+    setLastUsedTaste(taste)
     setShowLlmView(true)
     setIsLlmAnalyzing(true)
     setLlmAnalysisError(null)
@@ -376,10 +380,10 @@ export function ShotDetail({
       const profileData = shotData.profile as { description?: string; notes?: string } | undefined
       const profileDesc = profileData?.description || profileData?.notes
       if (profileDesc) formData.append('profile_description', profileDesc)
-      if (shotTaste) {
-        formData.append('taste_x', String(shotTaste.x))
-        formData.append('taste_y', String(shotTaste.y))
-        if (shotTaste.descriptors.length) formData.append('taste_descriptors', shotTaste.descriptors.join(','))
+      if (lastUsedTaste) {
+        formData.append('taste_x', String(lastUsedTaste.x))
+        formData.append('taste_y', String(lastUsedTaste.y))
+        if (lastUsedTaste.descriptors.length) formData.append('taste_descriptors', lastUsedTaste.descriptors.join(','))
       }
       const response = await fetch(`${serverUrl}/api/shots/analyze-llm`, { method: 'POST', body: formData })
       if (!response.ok) {

--- a/apps/web/src/components/ShotHistoryView/ShotFactsPanel.test.tsx
+++ b/apps/web/src/components/ShotHistoryView/ShotFactsPanel.test.tsx
@@ -44,4 +44,9 @@ describe('ShotFactsPanel', () => {
     const { container } = render(<ShotFactsPanel facts={{ ...facts, stages: [] }} />)
     expect(container.firstChild).toBeNull()
   })
+  it('renders compass adjustments when taste is provided', () => {
+    render(<ShotFactsPanel facts={facts} taste={{ x: -0.8, y: -0.6, descriptors: [] }} />)
+    expect(screen.getByText('analysis.facts.adjustmentsTitle')).toBeInTheDocument()
+    expect(screen.getByText(/grind_finer/i)).toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/ShotHistoryView/ShotFactsPanel.test.tsx
+++ b/apps/web/src/components/ShotHistoryView/ShotFactsPanel.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ShotFactsPanel } from './ShotFactsPanel'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const facts: ShotFacts = {
+  stages: [
+    { stage_name: 'Infusion', reached: true, control_mode: 'pressure', trigger_type: 'weight',
+      trigger_class: { kind: 'targeted', label: 'Targeted (yield reached)', reason: '' },
+      stall: { stalled: false, weight_gain: 30 },
+      channeling: { channeling: false, pressure_drop: 0.1, flow_rise: 0.1 },
+      curve_adherence: { target: 9, measured: 8.5, delta: -0.5 } },
+    { stage_name: 'Decline', reached: true, control_mode: 'pressure', trigger_type: 'time',
+      trigger_class: { kind: 'failsafe', label: 'Failsafe (timeout limit)', reason: '' },
+      stall: { stalled: true, weight_gain: 0.2 },
+      channeling: { channeling: true, pressure_drop: 3, flow_rise: 2 },
+      curve_adherence: null },
+  ],
+  phases: [],
+  weight: { actual: 36, target: 36, deviation_pct: 0 },
+  total_time_s: 30,
+}
+
+describe('ShotFactsPanel', () => {
+  it('renders a row per stage with its trigger label', () => {
+    render(<ShotFactsPanel facts={facts} />)
+    expect(screen.getByText('Infusion')).toBeInTheDocument()
+    expect(screen.getByText('Decline')).toBeInTheDocument()
+    expect(screen.getByText('Targeted (yield reached)')).toBeInTheDocument()
+    expect(screen.getByText('Failsafe (timeout limit)')).toBeInTheDocument()
+  })
+  it('shows stall and channeling flags when present', () => {
+    render(<ShotFactsPanel facts={facts} />)
+    expect(screen.getByText('analysis.facts.stalled')).toBeInTheDocument()
+    expect(screen.getByText('analysis.facts.channeling')).toBeInTheDocument()
+  })
+  it('renders nothing when facts has no reached stages', () => {
+    const { container } = render(<ShotFactsPanel facts={{ ...facts, stages: [] }} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/apps/web/src/components/ShotHistoryView/ShotFactsPanel.tsx
+++ b/apps/web/src/components/ShotHistoryView/ShotFactsPanel.tsx
@@ -1,11 +1,14 @@
 import { useTranslation } from 'react-i18next'
 import type { ShotFacts } from '../../lib/shotFacts'
+import { compassAdjustments } from '../../lib/compassRules'
+import type { StoredTaste } from '../../lib/shotTasteStore'
 
 interface Props {
   facts: ShotFacts
+  taste?: StoredTaste | null
 }
 
-export function ShotFactsPanel({ facts }: Props) {
+export function ShotFactsPanel({ facts, taste }: Props) {
   const { t } = useTranslation()
   const reached = facts.stages.filter(s => s.reached)
   if (reached.length === 0) return null
@@ -49,6 +52,22 @@ export function ShotFactsPanel({ facts }: Props) {
           </li>
         ))}
       </ul>
+      {taste && (() => {
+        const adj = compassAdjustments(taste.x, taste.y)
+        if (adj.length === 0) return null
+        return (
+          <div className="space-y-1">
+            <h4 className="text-xs font-semibold text-foreground">{t('analysis.facts.adjustmentsTitle')}</h4>
+            <ul className="space-y-1">
+              {adj.map((a, i) => (
+                <li key={`${a.kind}-${i}`} className="text-xs text-muted-foreground">
+                  <span className="font-mono">{a.kind}</span> — {a.reason}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/apps/web/src/components/ShotHistoryView/ShotFactsPanel.tsx
+++ b/apps/web/src/components/ShotHistoryView/ShotFactsPanel.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+interface Props {
+  facts: ShotFacts
+}
+
+export function ShotFactsPanel({ facts }: Props) {
+  const { t } = useTranslation()
+  const reached = facts.stages.filter(s => s.reached)
+  if (reached.length === 0) return null
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <h3 className="text-sm font-semibold text-foreground">{t('analysis.facts.title')}</h3>
+      <ul className="space-y-2">
+        {reached.map((s, i) => (
+          <li key={`${s.stage_name}-${i}`} className="flex flex-col gap-1 border-b border-border/50 pb-2 last:border-0 last:pb-0">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm font-medium text-foreground">{s.stage_name}</span>
+              {s.trigger_class && (
+                <span
+                  className={
+                    'text-xs px-2 py-0.5 rounded-full ' +
+                    (s.trigger_class.kind === 'targeted'
+                      ? 'bg-emerald-500/15 text-emerald-400'
+                      : s.trigger_class.kind === 'failsafe'
+                        ? 'bg-amber-500/15 text-amber-400'
+                        : 'bg-muted text-muted-foreground')
+                  }
+                >
+                  {s.trigger_class.label}
+                </span>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs">
+              {s.stall?.stalled && (
+                <span className="px-2 py-0.5 rounded bg-red-500/15 text-red-400">{t('analysis.facts.stalled')}</span>
+              )}
+              {s.channeling?.channeling && (
+                <span className="px-2 py-0.5 rounded bg-red-500/15 text-red-400">{t('analysis.facts.channeling')}</span>
+              )}
+              {s.curve_adherence && Math.abs(s.curve_adherence.delta) >= 0.5 && (
+                <span className="px-2 py-0.5 rounded bg-muted text-muted-foreground">
+                  {t('analysis.facts.curveDelta', { delta: s.curve_adherence.delta })}
+                </span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/web/src/components/ShotHistoryView/types.ts
+++ b/apps/web/src/components/ShotHistoryView/types.ts
@@ -1,4 +1,5 @@
 import type { ShotInfo, ShotData } from '@/hooks/useShotHistory'
+import type { ShotFacts } from '@/lib/shotFacts'
 
 // Re-export for convenience
 export type { ShotInfo, ShotData }
@@ -123,6 +124,7 @@ export interface LocalAnalysisResult {
   preinfusion_summary: PreinfusionSummary
   profile_info: ProfileInfo
   profile_target_curves?: ProfileTargetPoint[]
+  shot_facts?: ShotFacts
 }
 
 export interface ChartDataPoint {

--- a/apps/web/src/lib/analysisCoverage.test.ts
+++ b/apps/web/src/lib/analysisCoverage.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import * as lint from './analysisLint'
+
+describe('analysis coverage matrix (L5, native)', () => {
+  it('exposes degeneracy, structural, and fact-aware checks', () => {
+    expect(typeof lint.lintShotAnalysis).toBe('function')
+    expect(typeof lint.checkStructure).toBe('function')
+    expect(typeof lint.validateAgainstFacts).toBe('function')
+    expect(typeof lint.repairShotAnalysis).toBe('function')
+  })
+})

--- a/apps/web/src/lib/analysisLint.test.ts
+++ b/apps/web/src/lib/analysisLint.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { lintShotAnalysis, repairShotAnalysis } from './analysisLint'
+import { lintShotAnalysis, repairShotAnalysis, validateAgainstFacts, checkStructure } from './analysisLint'
+import { REQUIRED_ANALYSIS_SECTIONS } from './analysisSchema'
+import type { ShotFacts } from './shotFacts'
 
 const wellFormed = `## 1. Overall Assessment
 **Summary:** A balanced, well-extracted shot with good temperature stability.
@@ -96,9 +98,6 @@ describe('repairShotAnalysis', () => {
   })
 })
 
-import { validateAgainstFacts } from './analysisLint'
-import type { ShotFacts } from './shotFacts'
-
 const factsTargetedWeight: ShotFacts = {
   stages: [{ stage_name: 'Hold', reached: true, control_mode: 'pressure', trigger_type: 'weight',
     trigger_class: { kind: 'targeted', label: 'Targeted (yield reached)', reason: '' },
@@ -131,9 +130,6 @@ describe('validateAgainstFacts (K4)', () => {
     expect(validateAgainstFacts(text, facts).issues).not.toContain('unsupported-channeling')
   })
 })
-
-import { checkStructure } from './analysisLint'
-import { REQUIRED_ANALYSIS_SECTIONS } from './analysisSchema'
 
 describe('checkStructure (L1) + schema (L2)', () => {
   it('schema lists the five core sections', () => {

--- a/apps/web/src/lib/analysisLint.test.ts
+++ b/apps/web/src/lib/analysisLint.test.ts
@@ -131,3 +131,22 @@ describe('validateAgainstFacts (K4)', () => {
     expect(validateAgainstFacts(text, facts).issues).not.toContain('unsupported-channeling')
   })
 })
+
+import { checkStructure } from './analysisLint'
+import { REQUIRED_ANALYSIS_SECTIONS } from './analysisSchema'
+
+describe('checkStructure (L1) + schema (L2)', () => {
+  it('schema lists the five core sections', () => {
+    expect(REQUIRED_ANALYSIS_SECTIONS).toContain('Shot Performance')
+    expect(REQUIRED_ANALYSIS_SECTIONS.length).toBeGreaterThanOrEqual(5)
+  })
+  it('flags missing required sections', () => {
+    const r = checkStructure('## 1. Shot Performance\n- ok')
+    expect(r.valid).toBe(false)
+    expect(r.issues).toContain('missing-sections')
+  })
+  it('accepts text containing all required section titles', () => {
+    const text = REQUIRED_ANALYSIS_SECTIONS.map((s, i) => `## ${i + 1}. ${s}\n- content line here`).join('\n')
+    expect(checkStructure(text).valid).toBe(true)
+  })
+})

--- a/apps/web/src/lib/analysisLint.test.ts
+++ b/apps/web/src/lib/analysisLint.test.ts
@@ -95,3 +95,39 @@ describe('repairShotAnalysis', () => {
     expect(repaired).not.toMatch(/\n{3,}/)
   })
 })
+
+import { validateAgainstFacts } from './analysisLint'
+import type { ShotFacts } from './shotFacts'
+
+const factsTargetedWeight: ShotFacts = {
+  stages: [{ stage_name: 'Hold', reached: true, control_mode: 'pressure', trigger_type: 'weight',
+    trigger_class: { kind: 'targeted', label: 'Targeted (yield reached)', reason: '' },
+    stall: { stalled: false, weight_gain: 30 },
+    channeling: { channeling: false, pressure_drop: 0, flow_rise: 0 },
+    curve_adherence: null }],
+  phases: [], weight: { actual: 36, target: 36, deviation_pct: 0 }, total_time_s: 28,
+}
+
+describe('validateAgainstFacts (K4)', () => {
+  it('flags a targeted weight exit described as early termination', () => {
+    const text = '## 1. Shot Performance\n- The hold stage terminated early before reaching its goal.'
+    const r = validateAgainstFacts(text, factsTargetedWeight)
+    expect(r.valid).toBe(false)
+    expect(r.issues).toContain('mischaracterized-targeted-exit')
+  })
+  it('accepts analysis that frames the targeted exit as success', () => {
+    const text = '## 1. Shot Performance\n- The hold stage ended exactly on the weight target, a correct finish.'
+    expect(validateAgainstFacts(text, factsTargetedWeight).valid).toBe(true)
+  })
+  it('flags channeling claimed when no stage channeled', () => {
+    const text = '## 2. Root Cause\n- Severe channeling caused the pressure to collapse.'
+    const r = validateAgainstFacts(text, factsTargetedWeight)
+    expect(r.issues).toContain('unsupported-channeling')
+  })
+  it('does not flag channeling when a stage actually channeled', () => {
+    const facts: ShotFacts = { ...factsTargetedWeight, stages: [{ ...factsTargetedWeight.stages[0],
+      channeling: { channeling: true, pressure_drop: 3, flow_rise: 2 } }] }
+    const text = '- Channeling is evident from the pressure drop.'
+    expect(validateAgainstFacts(text, facts).issues).not.toContain('unsupported-channeling')
+  })
+})

--- a/apps/web/src/lib/analysisLint.ts
+++ b/apps/web/src/lib/analysisLint.ts
@@ -9,6 +9,8 @@
  * best-effort repair that collapses runaway repetition when a retry still fails.
  */
 
+import type { ShotFacts } from './shotFacts'
+
 export interface AnalysisLintResult {
   valid: boolean
   /** Machine-readable issue codes (e.g. 'empty', 'repetition', 'low-diversity'). */
@@ -102,4 +104,40 @@ export function repairShotAnalysis(text: string): string {
   }
 
   return out.join('\n').trim()
+}
+
+/** Phrases that frame a stage exit as a failure/early stop. */
+const EARLY_EXIT_PATTERNS = [
+  /terminat\w*\s+early/i,
+  /\bearly\s+terminat/i,
+  /ended?\s+(too\s+)?(early|prematurely)/i,
+  /\bcut\s+short\b/i,
+  /stopped?\s+before\s+reaching/i,
+]
+/** Phrases asserting channeling occurred. */
+const CHANNELING_ASSERTION = /\bchannel(?:ing|ed|s)?\b/i
+/** Phrases that negate channeling (so we don't flag "no channeling"). */
+const CHANNELING_NEGATION = /\b(no|not|without|absence of|isn'?t|wasn'?t)\b[^.]{0,30}channel/i
+
+/**
+ * Reject analyses that contradict the deterministic ShotFacts. High precision:
+ * only flags clear, well-supported contradictions.
+ */
+export function validateAgainstFacts(text: string, facts: ShotFacts): AnalysisLintResult {
+  const issues: string[] = []
+  const body = text ?? ''
+
+  const hasTargetedWeightExit = facts.stages.some(
+    s => s.reached && s.trigger_type === 'weight' && s.trigger_class?.kind === 'targeted',
+  )
+  if (hasTargetedWeightExit && EARLY_EXIT_PATTERNS.some(re => re.test(body))) {
+    issues.push('mischaracterized-targeted-exit')
+  }
+
+  const anyChanneling = facts.stages.some(s => s.channeling?.channeling)
+  if (!anyChanneling && CHANNELING_ASSERTION.test(body) && !CHANNELING_NEGATION.test(body)) {
+    issues.push('unsupported-channeling')
+  }
+
+  return { valid: issues.length === 0, issues }
 }

--- a/apps/web/src/lib/analysisLint.ts
+++ b/apps/web/src/lib/analysisLint.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ShotFacts } from './shotFacts'
+import { REQUIRED_ANALYSIS_SECTIONS } from './analysisSchema'
 
 export interface AnalysisLintResult {
   valid: boolean
@@ -140,4 +141,14 @@ export function validateAgainstFacts(text: string, facts: ShotFacts): AnalysisLi
   }
 
   return { valid: issues.length === 0, issues }
+}
+
+/**
+ * Verify the analysis contains each required section title (L1). Matches on the title text so
+ * it is robust to numbering/heading-level variations the model may introduce.
+ */
+export function checkStructure(text: string): AnalysisLintResult {
+  const body = (text ?? '').toLowerCase()
+  const missing = REQUIRED_ANALYSIS_SECTIONS.filter(s => !body.includes(s.toLowerCase()))
+  return { valid: missing.length === 0, issues: missing.length ? ['missing-sections'] : [] }
 }

--- a/apps/web/src/lib/analysisSchema.ts
+++ b/apps/web/src/lib/analysisSchema.ts
@@ -1,0 +1,17 @@
+/**
+ * Single source of truth for the shot-analysis section structure (L2).
+ * Consumed by the prompt builders and the structural linter so the format the model is asked
+ * to produce and the format we validate can never drift apart.
+ * Mirror of apps/server/analysis_schema.py.
+ */
+
+export const REQUIRED_ANALYSIS_SECTIONS = [
+  'Shot Performance',
+  'Root Cause Analysis',
+  'Setup Recommendations',
+  'Profile Recommendations',
+  'Profile Design Observations',
+] as const
+
+/** Optional taste section appended when compass taste is supplied. */
+export const OPTIONAL_TASTE_SECTION = 'Taste-Based Recommendations'

--- a/apps/web/src/lib/compassRules.test.ts
+++ b/apps/web/src/lib/compassRules.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { compassAdjustments } from './compassRules'
+
+describe('compassAdjustments (D6)', () => {
+  it('sour + weak suggests finer and hotter', () => {
+    const adj = compassAdjustments(-0.8, -0.6)
+    const kinds = adj.map(a => a.kind)
+    expect(kinds).toContain('grind_finer')
+    expect(kinds.some(k => ['temp_up', 'ratio_up', 'dose_up'].includes(k))).toBe(true)
+  })
+  it('bitter + strong suggests coarser', () => {
+    expect(compassAdjustments(0.8, 0.7).map(a => a.kind)).toContain('grind_coarser')
+  })
+  it('centered taste returns no changes', () => {
+    expect(compassAdjustments(0, 0)).toEqual([])
+  })
+})

--- a/apps/web/src/lib/compassRules.ts
+++ b/apps/web/src/lib/compassRules.ts
@@ -1,0 +1,38 @@
+/**
+ * Deterministic Espresso-Compass taste -> dial-in adjustment rules (D6).
+ * X: -1 sour ... +1 bitter.   Y: -1 weak/thin ... +1 strong/heavy.
+ * TS parity of apps/server/services/compass_rules.py — keep DEADBAND identical.
+ */
+
+export const COMPASS_DEADBAND = 0.25
+
+export type CompassAdjustmentKind =
+  | 'grind_finer' | 'grind_coarser' | 'temp_up' | 'temp_down'
+  | 'ratio_up' | 'ratio_down' | 'dose_up'
+
+export interface CompassAdjustment {
+  kind: CompassAdjustmentKind
+  axis: 'x' | 'y'
+  reason: string
+}
+
+export function compassAdjustments(tasteX: number, tasteY: number): CompassAdjustment[] {
+  const adjustments: CompassAdjustment[] = []
+
+  if (tasteX <= -COMPASS_DEADBAND) {
+    adjustments.push({ kind: 'grind_finer', axis: 'x', reason: 'Sour/acidic indicates under-extraction; grind finer to raise yield.' })
+    adjustments.push({ kind: 'temp_up', axis: 'x', reason: 'A few degrees hotter increases extraction of sweet/bitter compounds.' })
+  } else if (tasteX >= COMPASS_DEADBAND) {
+    adjustments.push({ kind: 'grind_coarser', axis: 'x', reason: 'Bitter/harsh indicates over-extraction; grind coarser to lower yield.' })
+    adjustments.push({ kind: 'temp_down', axis: 'x', reason: 'A few degrees cooler reduces harsh bitter extraction.' })
+  }
+
+  if (tasteY <= -COMPASS_DEADBAND) {
+    adjustments.push({ kind: 'ratio_up', axis: 'y', reason: 'Weak/thin body; lower the brew ratio (less water per dose) for more concentration.' })
+    adjustments.push({ kind: 'dose_up', axis: 'y', reason: 'A larger dose increases strength and body.' })
+  } else if (tasteY >= COMPASS_DEADBAND) {
+    adjustments.push({ kind: 'ratio_down', axis: 'y', reason: 'Strong/heavy; raise the brew ratio (more water per dose) to lighten.' })
+  }
+
+  return adjustments
+}

--- a/apps/web/src/lib/shotFacts.test.ts
+++ b/apps/web/src/lib/shotFacts.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { classifyTrigger, detectStall, detectChanneling, buildShotFacts } from './shotFacts'
+
+describe('classifyTrigger (#423)', () => {
+  it('weight is always targeted', () => {
+    expect(classifyTrigger('pressure', 'weight', 2).kind).toBe('targeted')
+  })
+  it('time-only trigger is planned duration', () => {
+    expect(classifyTrigger('flow', 'time', 1).kind).toBe('targeted')
+  })
+  it('time with other triggers is failsafe timeout', () => {
+    const r = classifyTrigger('flow', 'time', 2)
+    expect(r.kind).toBe('failsafe')
+    expect(r.label.toLowerCase()).toContain('timeout')
+  })
+  it('flow control + pressure trigger is puck resistance', () => {
+    expect(classifyTrigger('flow', 'pressure', 2).kind).toBe('targeted')
+  })
+  it('pressure control + flow-only trigger is planned transition', () => {
+    expect(classifyTrigger('pressure', 'flow', 1).kind).toBe('targeted')
+  })
+  it('pressure control + flow with others is failsafe channeling', () => {
+    expect(classifyTrigger('pressure', 'flow', 2).kind).toBe('failsafe')
+  })
+  it('pressure control + pressure trigger is threshold', () => {
+    expect(classifyTrigger('pressure', 'pressure', 1).kind).toBe('targeted')
+  })
+  it('unknown combo returns unknown', () => {
+    expect(classifyTrigger('power', 'weird', 1).kind).toBe('unknown')
+  })
+})
+
+describe('detectStall / detectChanneling', () => {
+  const ed = {
+    duration: 10, weight_gain: 2, end_weight: 8,
+    start_pressure: 1, end_pressure: 6, avg_pressure: 4, max_pressure: 6.5, min_pressure: 1,
+    start_flow: 4, end_flow: 0.5, avg_flow: 2, max_flow: 4.5,
+  }
+  it('flags stall on time failsafe with low gain', () => {
+    const stage = {
+      stage_type: 'pressure',
+      exit_triggers: [{ type: 'flow' }, { type: 'time' }],
+      exit_trigger_result: { triggered: { type: 'time' } },
+      execution_data: { ...ed, weight_gain: 0.3 },
+    }
+    expect(detectStall(stage).stalled).toBe(true)
+  })
+  it('no stall when weight trigger', () => {
+    const stage = { stage_type: 'flow', exit_triggers: [{ type: 'weight' }], exit_trigger_result: { triggered: { type: 'weight' } }, execution_data: ed }
+    expect(detectStall(stage).stalled).toBe(false)
+  })
+  it('flags channeling on pressure drop with flow rise', () => {
+    expect(detectChanneling({ ...ed, start_pressure: 8, end_pressure: 3, start_flow: 1, end_flow: 5 }).channeling).toBe(true)
+  })
+  it('no channeling on stable stage', () => {
+    expect(detectChanneling({ ...ed, start_pressure: 6, end_pressure: 6.2, start_flow: 2, end_flow: 2.1 }).channeling).toBe(false)
+  })
+})
+
+describe('buildShotFacts', () => {
+  it('classifies each stage and reads total time from shot_summary', () => {
+    const analysis = {
+      shot_summary: { total_time: 30 },
+      weight_analysis: { actual: 36, target: 36, deviation_percent: 0 },
+      stage_analyses: [{
+        stage_name: 'Infusion', stage_type: 'pressure',
+        exit_triggers: [{ type: 'weight' }],
+        exit_trigger_result: { triggered: { type: 'weight' } },
+        execution_data: { duration: 10, weight_gain: 2, end_weight: 8, start_pressure: 6, end_pressure: 6, avg_pressure: 6, max_pressure: 6, min_pressure: 6, start_flow: 2, end_flow: 2, avg_flow: 2, max_flow: 2 },
+      }],
+    }
+    const facts = buildShotFacts(analysis)
+    expect(facts.stages).toHaveLength(1)
+    expect(facts.stages[0].trigger_class?.kind).toBe('targeted')
+    expect(facts.total_time_s).toBe(30)
+  })
+})

--- a/apps/web/src/lib/shotFacts.test.ts
+++ b/apps/web/src/lib/shotFacts.test.ts
@@ -74,4 +74,34 @@ describe('buildShotFacts', () => {
     expect(facts.stages[0].trigger_class?.kind).toBe('targeted')
     expect(facts.total_time_s).toBe(30)
   })
+
+  it('computes curve adherence from profile_target_value', () => {
+    const analysis = {
+      shot_summary: { total_time: 30 },
+      weight_analysis: { actual: 36, target: 36, deviation_percent: 0 },
+      stage_analyses: [{
+        stage_name: 'Ramp', stage_type: 'pressure', profile_target_value: 9,
+        exit_triggers: [{ type: 'pressure' }],
+        exit_trigger_result: { triggered: { type: 'pressure' } },
+        execution_data: { duration: 10, weight_gain: 2, end_weight: 8, start_pressure: 6, end_pressure: 9, avg_pressure: 8.5, max_pressure: 9, min_pressure: 6, start_flow: 2, end_flow: 2, avg_flow: 2, max_flow: 2 },
+      }],
+    }
+    const ca = buildShotFacts(analysis).stages[0].curve_adherence
+    expect(ca).not.toBeNull()
+    expect(ca?.target).toBe(9)
+    expect(ca?.measured).toBe(8.5)
+    expect(ca?.delta).toBe(-0.5)
+  })
+
+  it('curve adherence is null without a numeric target', () => {
+    const analysis = {
+      stage_analyses: [{
+        stage_name: 'Ramp', stage_type: 'pressure',
+        exit_triggers: [{ type: 'pressure' }],
+        exit_trigger_result: { triggered: { type: 'pressure' } },
+        execution_data: { duration: 10, weight_gain: 2, end_weight: 8, start_pressure: 6, end_pressure: 9, avg_pressure: 8.5, max_pressure: 9, min_pressure: 6, start_flow: 2, end_flow: 2, avg_flow: 2, max_flow: 2 },
+      }],
+    }
+    expect(buildShotFacts(analysis).stages[0].curve_adherence).toBeNull()
+  })
 })

--- a/apps/web/src/lib/shotFacts.ts
+++ b/apps/web/src/lib/shotFacts.ts
@@ -1,0 +1,151 @@
+/**
+ * Deterministic shot-fact derivation (#423 + diagnostic signals).
+ * TS parity of apps/server/services/shot_facts.py — keep thresholds identical.
+ */
+
+// Threshold constants — keep identical to shot_facts.py
+export const STALL_MIN_WEIGHT_GAIN_G = 0.5
+export const CHANNELING_PRESSURE_DROP_BAR = 1.5
+export const CHANNELING_FLOW_RISE_MLS = 1.5
+
+export type TriggerKind = 'targeted' | 'failsafe' | 'unknown'
+export interface TriggerClass { kind: TriggerKind; label: string; reason: string }
+export interface StallResult { stalled: boolean; weight_gain: number }
+export interface ChannelingResult { channeling: boolean; pressure_drop: number; flow_rise: number }
+
+interface ExecutionData {
+  duration?: number; weight_gain?: number; end_weight?: number
+  start_pressure?: number; end_pressure?: number; avg_pressure?: number; max_pressure?: number; min_pressure?: number
+  start_flow?: number; end_flow?: number; avg_flow?: number; max_flow?: number
+}
+interface StageAnalysis {
+  stage_name?: string; stage_type?: string; type?: string
+  exit_triggers?: Array<{ type?: string }>
+  exit_trigger_result?: { triggered?: { type?: string } | null } | null
+  execution_data?: ExecutionData | null
+  profile_target?: { target_value?: number } | unknown
+}
+export interface ShotFactStage {
+  stage_name?: string
+  reached: boolean
+  control_mode?: string
+  trigger_type?: string
+  trigger_class?: TriggerClass
+  stall?: StallResult
+  channeling?: ChannelingResult
+  curve_adherence?: { target: number; measured: number; delta: number } | null
+}
+export interface ShotFacts {
+  stages: ShotFactStage[]
+  phases: Array<{ stage_name?: string; phase: string; avg_pressure?: number; avg_flow?: number; weight_gain?: number }>
+  weight: { actual?: number; target?: number; deviation_pct?: number }
+  total_time_s?: number
+}
+
+const n = (v: unknown): number => (typeof v === 'number' && !Number.isNaN(v) ? v : 0)
+const r2 = (v: number): number => Math.round(v * 100) / 100
+
+export function classifyTrigger(stageControlMode: string, triggerType: string, totalTriggers: number): TriggerClass {
+  if (triggerType === 'weight') {
+    return { kind: 'targeted', label: 'Targeted (yield reached)', reason: 'Weight is the ultimate goal of the shot.' }
+  }
+  if (triggerType === 'time') {
+    return totalTriggers === 1
+      ? { kind: 'targeted', label: 'Targeted (planned duration)', reason: 'Time is the only trigger, so this is an intentional timed stage.' }
+      : { kind: 'failsafe', label: 'Failsafe (timeout limit)', reason: 'Stage hit its time backstop before another target was reached.' }
+  }
+  if (stageControlMode === 'flow' && triggerType === 'pressure') {
+    return { kind: 'targeted', label: 'Targeted (puck resistance achieved)', reason: 'Flow-controlled stage reached its intended pressure.' }
+  }
+  if (stageControlMode === 'pressure' && triggerType === 'flow') {
+    return totalTriggers === 1
+      ? { kind: 'targeted', label: 'Targeted (planned flow transition)', reason: 'Flow is the only trigger, so the transition is intentional.' }
+      : { kind: 'failsafe', label: 'Failsafe (caught channeling or choking)', reason: 'Pressure-controlled stage exited on a flow backstop.' }
+  }
+  if (stageControlMode === 'pressure' && triggerType === 'pressure') {
+    return { kind: 'targeted', label: 'Targeted (pressure threshold reached)', reason: 'Pressure-controlled stage reached its target pressure.' }
+  }
+  return { kind: 'unknown', label: 'Unknown', reason: 'Trigger/control-mode combination is not classified.' }
+}
+
+function stageControlMode(stage: StageAnalysis): string {
+  const t = (stage.stage_type ?? stage.type ?? '').toLowerCase()
+  if (t.includes('flow')) return 'flow'
+  if (t.includes('pressure')) return 'pressure'
+  return 'unknown'
+}
+
+export function detectStall(stage: StageAnalysis): StallResult {
+  const trigType = stage.exit_trigger_result?.triggered?.type ?? ''
+  const total = (stage.exit_triggers ?? []).length
+  const gain = n(stage.execution_data?.weight_gain)
+  const klass = classifyTrigger(stageControlMode(stage), trigType, total)
+  const stalled = klass.kind === 'failsafe' && trigType === 'time' && gain < STALL_MIN_WEIGHT_GAIN_G
+  return { stalled, weight_gain: r2(gain) }
+}
+
+export function detectChanneling(ed: ExecutionData): ChannelingResult {
+  const pDrop = n(ed.start_pressure) - n(ed.end_pressure)
+  const fRise = n(ed.end_flow) - n(ed.start_flow)
+  return {
+    channeling: pDrop >= CHANNELING_PRESSURE_DROP_BAR && fRise >= CHANNELING_FLOW_RISE_MLS,
+    pressure_drop: r2(pDrop),
+    flow_rise: r2(fRise),
+  }
+}
+
+function buildPhases(stages: StageAnalysis[]): ShotFacts['phases'] {
+  return stages
+    .filter(s => s.execution_data)
+    .map(s => {
+      const ed = s.execution_data as ExecutionData
+      const avgP = n(ed.avg_pressure)
+      let phase: string
+      if (avgP < 3.0) phase = 'pre-infusion'
+      else if (n(ed.end_pressure) > n(ed.start_pressure)) phase = 'ramp'
+      else if (n(ed.end_pressure) < n(ed.start_pressure)) phase = 'decline'
+      else phase = 'peak'
+      return { stage_name: s.stage_name, phase, avg_pressure: ed.avg_pressure, avg_flow: ed.avg_flow, weight_gain: ed.weight_gain }
+    })
+}
+
+function curveAdherence(stage: StageAnalysis): ShotFactStage['curve_adherence'] {
+  const pt = stage.profile_target as { target_value?: number } | undefined
+  const target = pt?.target_value
+  if (target == null) return null
+  const mode = stageControlMode(stage)
+  const measured = mode === 'pressure' ? stage.execution_data?.avg_pressure : stage.execution_data?.avg_flow
+  if (measured == null) return null
+  return { target, measured, delta: r2(measured - target) }
+}
+
+export function buildShotFacts(analysis: {
+  stage_analyses?: StageAnalysis[]
+  weight_analysis?: { actual?: number; target?: number; deviation_percent?: number }
+  shot_summary?: { total_time?: number }
+  overall_metrics?: { total_time?: number }
+}): ShotFacts {
+  const stages = analysis.stage_analyses ?? []
+  const stagesOut: ShotFactStage[] = stages.map(s => {
+    if (!s.execution_data) return { stage_name: s.stage_name, reached: false }
+    const trigType = s.exit_trigger_result?.triggered?.type ?? ''
+    const total = (s.exit_triggers ?? []).length
+    return {
+      stage_name: s.stage_name,
+      reached: true,
+      control_mode: stageControlMode(s),
+      trigger_type: trigType,
+      trigger_class: classifyTrigger(stageControlMode(s), trigType, total),
+      stall: detectStall(s),
+      channeling: detectChanneling(s.execution_data),
+      curve_adherence: curveAdherence(s),
+    }
+  })
+  const wa = analysis.weight_analysis ?? {}
+  return {
+    stages: stagesOut,
+    phases: buildPhases(stages),
+    weight: { actual: wa.actual, target: wa.target, deviation_pct: wa.deviation_percent },
+    total_time_s: analysis.shot_summary?.total_time ?? analysis.overall_metrics?.total_time,
+  }
+}

--- a/apps/web/src/lib/shotFacts.ts
+++ b/apps/web/src/lib/shotFacts.ts
@@ -24,6 +24,7 @@ interface StageAnalysis {
   exit_trigger_result?: { triggered?: { type?: string } | null } | null
   execution_data?: ExecutionData | null
   profile_target?: { target_value?: number } | unknown
+  profile_target_value?: number | null
 }
 export interface ShotFactStage {
   stage_name?: string
@@ -110,8 +111,7 @@ function buildPhases(stages: StageAnalysis[]): ShotFacts['phases'] {
 }
 
 function curveAdherence(stage: StageAnalysis): ShotFactStage['curve_adherence'] {
-  const pt = stage.profile_target as { target_value?: number } | undefined
-  const target = pt?.target_value
+  const target = typeof stage.profile_target_value === 'number' ? stage.profile_target_value : null
   if (target == null) return null
   const mode = resolveStageControlMode(stage)
   const measured = mode === 'pressure' ? stage.execution_data?.avg_pressure : stage.execution_data?.avg_flow

--- a/apps/web/src/lib/shotFacts.ts
+++ b/apps/web/src/lib/shotFacts.ts
@@ -68,7 +68,7 @@ export function classifyTrigger(stageControlMode: string, triggerType: string, t
   return { kind: 'unknown', label: 'Unknown', reason: 'Trigger/control-mode combination is not classified.' }
 }
 
-function stageControlMode(stage: StageAnalysis): string {
+function resolveStageControlMode(stage: StageAnalysis): string {
   const t = (stage.stage_type ?? stage.type ?? '').toLowerCase()
   if (t.includes('flow')) return 'flow'
   if (t.includes('pressure')) return 'pressure'
@@ -79,7 +79,7 @@ export function detectStall(stage: StageAnalysis): StallResult {
   const trigType = stage.exit_trigger_result?.triggered?.type ?? ''
   const total = (stage.exit_triggers ?? []).length
   const gain = n(stage.execution_data?.weight_gain)
-  const klass = classifyTrigger(stageControlMode(stage), trigType, total)
+  const klass = classifyTrigger(resolveStageControlMode(stage), trigType, total)
   const stalled = klass.kind === 'failsafe' && trigType === 'time' && gain < STALL_MIN_WEIGHT_GAIN_G
   return { stalled, weight_gain: r2(gain) }
 }
@@ -113,7 +113,7 @@ function curveAdherence(stage: StageAnalysis): ShotFactStage['curve_adherence'] 
   const pt = stage.profile_target as { target_value?: number } | undefined
   const target = pt?.target_value
   if (target == null) return null
-  const mode = stageControlMode(stage)
+  const mode = resolveStageControlMode(stage)
   const measured = mode === 'pressure' ? stage.execution_data?.avg_pressure : stage.execution_data?.avg_flow
   if (measured == null) return null
   return { target, measured, delta: r2(measured - target) }
@@ -133,9 +133,9 @@ export function buildShotFacts(analysis: {
     return {
       stage_name: s.stage_name,
       reached: true,
-      control_mode: stageControlMode(s),
+      control_mode: resolveStageControlMode(s),
       trigger_type: trigType,
-      trigger_class: classifyTrigger(stageControlMode(s), trigType, total),
+      trigger_class: classifyTrigger(resolveStageControlMode(s), trigType, total),
       stall: detectStall(s),
       channeling: detectChanneling(s.execution_data),
       curve_adherence: curveAdherence(s),

--- a/apps/web/src/lib/shotTasteStore.test.ts
+++ b/apps/web/src/lib/shotTasteStore.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { saveShotTaste, loadShotTaste, shotTasteKey } from './shotTasteStore'
+
+describe('shotTasteStore (U3)', () => {
+  beforeEach(() => localStorage.clear())
+  it('round-trips taste for a shot key', () => {
+    const taste = { x: -0.5, y: 0.3, descriptors: ['sour'] }
+    saveShotTaste('Prof', '2024-01-01', 'a.json', taste)
+    expect(loadShotTaste('Prof', '2024-01-01', 'a.json')).toEqual(taste)
+  })
+  it('returns null when nothing stored', () => {
+    expect(loadShotTaste('Prof', '2024-01-01', 'missing.json')).toBeNull()
+  })
+  it('builds a stable composite key', () => {
+    expect(shotTasteKey('P', 'd', 'f')).toBe('shot-taste:P|d|f')
+  })
+})

--- a/apps/web/src/lib/shotTasteStore.test.ts
+++ b/apps/web/src/lib/shotTasteStore.test.ts
@@ -14,4 +14,12 @@ describe('shotTasteStore (U3)', () => {
   it('builds a stable composite key', () => {
     expect(shotTasteKey('P', 'd', 'f')).toBe('shot-taste:P|d|f')
   })
+  it('encodes delimiter characters to avoid key collisions', () => {
+    // Two distinct shots that would collide under naive '|' joining.
+    saveShotTaste('A|B', 'd', 'f', { x: 1, y: 1, descriptors: ['bitter'] })
+    saveShotTaste('A', 'B|d', 'f', { x: -1, y: -1, descriptors: ['sour'] })
+    expect(loadShotTaste('A|B', 'd', 'f')).toEqual({ x: 1, y: 1, descriptors: ['bitter'] })
+    expect(loadShotTaste('A', 'B|d', 'f')).toEqual({ x: -1, y: -1, descriptors: ['sour'] })
+    expect(shotTasteKey('A|B', 'd', 'f')).not.toBe(shotTasteKey('A', 'B|d', 'f'))
+  })
 })

--- a/apps/web/src/lib/shotTasteStore.ts
+++ b/apps/web/src/lib/shotTasteStore.ts
@@ -7,7 +7,8 @@ export interface StoredTaste {
 }
 
 export function shotTasteKey(profileName: string, date: string, filename: string): string {
-  return `shot-taste:${profileName}|${date}|${filename}`
+  const enc = encodeURIComponent
+  return `shot-taste:${enc(profileName)}|${enc(date)}|${enc(filename)}`
 }
 
 export function saveShotTaste(profileName: string, date: string, filename: string, taste: StoredTaste): void {

--- a/apps/web/src/lib/shotTasteStore.ts
+++ b/apps/web/src/lib/shotTasteStore.ts
@@ -1,0 +1,33 @@
+/** Persist the compass taste a user supplied for a given shot (U3). */
+
+export interface StoredTaste {
+  x: number
+  y: number
+  descriptors: string[]
+}
+
+export function shotTasteKey(profileName: string, date: string, filename: string): string {
+  return `shot-taste:${profileName}|${date}|${filename}`
+}
+
+export function saveShotTaste(profileName: string, date: string, filename: string, taste: StoredTaste): void {
+  try {
+    localStorage.setItem(shotTasteKey(profileName, date, filename), JSON.stringify(taste))
+  } catch {
+    // storage unavailable (private mode / quota) — non-critical
+  }
+}
+
+export function loadShotTaste(profileName: string, date: string, filename: string): StoredTaste | null {
+  try {
+    const raw = localStorage.getItem(shotTasteKey(profileName, date, filename))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredTaste
+    if (typeof parsed.x === 'number' && typeof parsed.y === 'number' && Array.isArray(parsed.descriptors)) {
+      return parsed
+    }
+    return null
+  } catch {
+    return null
+  }
+}

--- a/apps/web/src/services/ai/BrowserAIService.ts
+++ b/apps/web/src/services/ai/BrowserAIService.ts
@@ -30,7 +30,7 @@ import { retryWithBackoff } from './retryUtils'
 import i18n from 'i18next'
 
 import { STORAGE_KEYS } from '@/lib/constants'
-import { lintShotAnalysis, repairShotAnalysis } from '@/lib/analysisLint'
+import { lintShotAnalysis, repairShotAnalysis, checkStructure } from '@/lib/analysisLint'
 import { safeRandomUUID } from '@/lib/uuid'
 import { AIServiceError, type AIErrorCode as AIErrorCodeBase } from './aiErrors'
 import { getProviderForMethod, isAIConfigured } from './providers'
@@ -144,9 +144,10 @@ export function createBrowserAIService(): AIService {
       // back to a best-effort repair so the user still gets usable analysis.
       const response = await runAnalysis()
       let text = response.text
-      if (!lintShotAnalysis(text).valid) {
+      const valid = (txt: string) => lintShotAnalysis(txt).valid && checkStructure(txt).valid
+      if (!valid(text)) {
         const retry = await runAnalysis()
-        text = lintShotAnalysis(retry.text).valid
+        text = valid(retry.text)
           ? retry.text
           : repairShotAnalysis(retry.text.length >= text.length ? retry.text : text)
       }

--- a/apps/web/src/services/ai/analysisKnowledge.test.ts
+++ b/apps/web/src/services/ai/analysisKnowledge.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { ANALYSIS_KNOWLEDGE, buildFactSheet } from './analysisKnowledge'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+describe('ANALYSIS_KNOWLEDGE', () => {
+  it('covers trigger classes + channeling', () => {
+    expect(ANALYSIS_KNOWLEDGE).toContain('Targeted')
+    expect(ANALYSIS_KNOWLEDGE).toContain('Failsafe')
+    expect(ANALYSIS_KNOWLEDGE.toLowerCase()).toContain('channeling')
+  })
+})
+
+describe('buildFactSheet', () => {
+  const facts: ShotFacts = {
+    stages: [
+      { stage_name: 'Infusion', reached: true, control_mode: 'pressure', trigger_type: 'weight',
+        trigger_class: { kind: 'targeted', label: 'Targeted (yield reached)', reason: '' },
+        stall: { stalled: false, weight_gain: 30 },
+        channeling: { channeling: false, pressure_drop: 0.1, flow_rise: 0.1 },
+        curve_adherence: { target: 9, measured: 8.5, delta: -0.5 } },
+      { stage_name: 'Decline', reached: true, control_mode: 'pressure', trigger_type: 'time',
+        trigger_class: { kind: 'failsafe', label: 'Failsafe (timeout limit)', reason: '' },
+        stall: { stalled: true, weight_gain: 0.2 },
+        channeling: { channeling: true, pressure_drop: 3, flow_rise: 2 },
+        curve_adherence: null },
+    ],
+    phases: [],
+    weight: { actual: 36, target: 36, deviation_pct: 0 },
+    total_time_s: 30,
+  }
+
+  it('renders stage classifications and weight', () => {
+    const sheet = buildFactSheet(facts)
+    expect(sheet).toContain('Infusion')
+    expect(sheet).toContain('Targeted (yield reached)')
+    expect(sheet).toContain('36')
+  })
+
+  it('flags stall and channeling', () => {
+    const sheet = buildFactSheet(facts).toLowerCase()
+    expect(sheet).toContain('stall')
+    expect(sheet).toContain('channel')
+  })
+})

--- a/apps/web/src/services/ai/analysisKnowledge.ts
+++ b/apps/web/src/services/ai/analysisKnowledge.ts
@@ -64,3 +64,18 @@ export function buildFactSheet(facts: ShotFacts): string {
   }
   return lines.join('\n')
 }
+
+export const FEW_SHOT_ANALYSIS_EXAMPLE = `### Worked Example (format + reasoning reference — do not copy its numbers)
+Facts: Pre-infusion [flow] exit = Targeted (planned duration); Ramp [pressure] exit = Targeted
+(pressure threshold reached); Hold [pressure] exit = Targeted (yield reached); final weight 36 g
+(target 36 g, deviation 0%); total time 28 s.
+
+Good analysis excerpt:
+## 1. Shot Performance
+**What Happened:**
+- Pre-infusion ran its planned duration, then pressure ramped cleanly to target.
+- The hold stage ended exactly on the weight target — a correct, intentional finish.
+**Assessment:** Good
+
+Note how every claim maps to a fact, no values are invented, and the Targeted weight exit is
+described as success, not "early termination".`

--- a/apps/web/src/services/ai/analysisKnowledge.ts
+++ b/apps/web/src/services/ai/analysisKnowledge.ts
@@ -1,0 +1,66 @@
+/**
+ * Analysis-specific knowledge base + fact-sheet renderer (K1 + K2).
+ * Mirror of apps/server/analysis_knowledge.py — keep the two texts in sync.
+ */
+import type { ShotFacts } from '../../lib/shotFacts'
+
+export const ANALYSIS_KNOWLEDGE = `You are reasoning about a single espresso extraction. Apply this framework:
+
+EXIT TRIGGER CLASSIFICATION (critical — do not confuse intent with failure):
+- A stage ends when one of its exit triggers fires. Classify each as Targeted or Failsafe:
+  - Targeted: the stage reached the outcome it was designed for. Examples: a weight trigger
+    (yield reached), a time trigger that is the stage's ONLY trigger (planned duration), a
+    flow-controlled stage hitting its target pressure (puck resistance achieved), a
+    pressure-controlled stage hitting target pressure, or a pressure-controlled stage whose
+    ONLY trigger is flow (planned flow transition).
+  - Failsafe: a backstop fired before the real target. Examples: a time trigger firing when
+    OTHER triggers also exist (timeout), or a pressure-controlled stage exiting on a flow
+    backstop when other triggers exist (caught channeling or choking).
+- NEVER describe a Targeted exit as a problem. A short stage that hit its weight target is a
+  correct, successful outcome — not "early termination".
+
+DIAGNOSTIC SIGNALS:
+- Stall: a stage exits on a time failsafe with negligible weight gain (< 0.5 g). Indicates the
+  puck choked or flow collapsed. Suggest a coarser grind or revisiting the pressure target.
+- Channeling: pressure falls while flow rises within the same stage. Indicates an uneven puck.
+  Suggest distribution/puck-prep changes, not profile changes, as the first remedy.
+- Curve adherence: when measured average diverges from the stage's target by a meaningful margin,
+  the machine could not follow the profile — usually a grind/dose mismatch, not a profile flaw.
+
+EXTRACTION THEORY:
+- Sour/acidic => under-extraction => grind finer or raise temperature.
+- Bitter/harsh => over-extraction => grind coarser or lower temperature.
+- Weak/thin body => lower brew ratio (less water per dose) or larger dose.
+- Strong/heavy => raise brew ratio.
+
+DISCIPLINE:
+- Only state facts supported by the data provided. Do NOT invent pressures, temperatures, weights,
+  or events that are not in the fact sheet. If a value is unknown, say so.
+- Prefer one or two high-confidence, specific, numeric recommendations over many vague ones.`
+
+const fmtNum = (v: number | null | undefined): string =>
+  v == null ? 'n/a' : (typeof v === 'number' ? `${+v.toFixed(2).replace(/\.?0+$/, '')}` : String(v))
+
+export function buildFactSheet(facts: ShotFacts): string {
+  const lines: string[] = ['### Deterministic Shot Facts (authoritative — trust over raw telemetry)']
+  const w = facts.weight ?? {}
+  lines.push(`- Final weight: ${fmtNum(w.actual)} g (target ${fmtNum(w.target)} g, deviation ${fmtNum(w.deviation_pct)}%).`)
+  lines.push(`- Total shot time: ${fmtNum(facts.total_time_s)} s.`)
+  lines.push('- Stage-by-stage:')
+  for (const s of facts.stages) {
+    if (!s.reached) {
+      lines.push(`  - ${s.stage_name}: not reached during this shot.`)
+      continue
+    }
+    const parts: string[] = [`exit = ${s.trigger_class?.label ?? 'Unknown'}`]
+    if (s.stall?.stalled) parts.push(`STALL (only ${fmtNum(s.stall.weight_gain)} g gained)`)
+    if (s.channeling?.channeling) {
+      parts.push(`CHANNELING (pressure -${fmtNum(s.channeling.pressure_drop)} bar, flow +${fmtNum(s.channeling.flow_rise)} ml/s)`)
+    }
+    if (s.curve_adherence && Math.abs(s.curve_adherence.delta) >= 0.5) {
+      parts.push(`curve off-target by ${fmtNum(s.curve_adherence.delta)}`)
+    }
+    lines.push(`  - ${s.stage_name} [${s.control_mode}]: ${parts.join('; ')}.`)
+  }
+  return lines.join('\n')
+}

--- a/apps/web/src/services/ai/profilePromptFull.ts
+++ b/apps/web/src/services/ai/profilePromptFull.ts
@@ -166,7 +166,7 @@ Profile JSON structure: {name, author, stages[], variables[], temperature}
 
 `
 
-const PROFILING_KNOWLEDGE = `ESPRESSO PROFILING GUIDE:
+export const PROFILING_KNOWLEDGE = `ESPRESSO PROFILING GUIDE:
 
 ## Core Concepts
 - Flow Rate: Higher = acidity/clarity, Lower = body/sweetness

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -9,6 +9,7 @@ import { deriveStructuralTags } from '@/lib/profileAnalysis'
 import type { AnalyzableProfile } from '@/lib/profileAnalysis'
 import { AI_TAGS_PROMPT, parseAiTags, stripTagsLine } from '@/lib/tags'
 import { buildShotFacts } from '@/lib/shotFacts'
+import { lintShotAnalysis, repairShotAnalysis, validateAgainstFacts } from '@/lib/analysisLint'
 import { buildAnalyzeLlmPrompt } from './analyzeLlmPrompt'
 import { buildTasteContext } from '../ai/prompts'
 import {
@@ -3031,6 +3032,7 @@ export function installDirectModeInterceptor(): void {
             ? buildTasteContext(tasteX, tasteY, tasteDescriptors)
             : ''
 
+          const facts = buildShotFacts(richAnalysis as Parameters<typeof buildShotFacts>[0])
           const prompt = buildAnalyzeLlmPrompt({
             profileName: pName,
             temperature: shotProfile?.temperature ?? null,
@@ -3038,7 +3040,7 @@ export function installDirectModeInterceptor(): void {
             profileDescription: profileDescription ?? '',
             profileVars,
             cleanStages,
-            facts: buildShotFacts(richAnalysis as Parameters<typeof buildShotFacts>[0]),
+            facts,
             tasteContext,
             graphSamples,
           })
@@ -3048,13 +3050,21 @@ export function installDirectModeInterceptor(): void {
             return jsonResponse({ status: 'error', message: aiNotConfiguredMessage() })
           }
           const analyzeProvider = getProviderForMethod('analyzeShot')
-          const response = await retryWithBackoff(() =>
-            analyzeProvider.generateText({
+          const gen = async () => {
+            const r = await retryWithBackoff(() => analyzeProvider.generateText({
               contents: [{ role: 'user', parts: [{ text: prompt }] }],
-            })
-          ) as { text?: string }
-
-          const analysisText = response.text ?? ''
+            })) as { text?: string }
+            return r.text ?? ''
+          }
+          let analysisText = await gen()
+          let lint = lintShotAnalysis(analysisText)
+          let factCheck = validateAgainstFacts(analysisText, facts)
+          if (!lint.valid || !factCheck.valid) {
+            analysisText = await gen()  // one retry
+            lint = lintShotAnalysis(analysisText)
+            factCheck = validateAgainstFacts(analysisText, facts)
+          }
+          if (!lint.valid) analysisText = repairShotAnalysis(analysisText)
           return jsonResponse({
             status: 'success',
             llm_analysis: analysisText,

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -618,6 +618,335 @@ function generateShotAlignedTargetCurves(
   return curves.sort((a, b) => safeNumber(a.time) - safeNumber(b.time))
 }
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type HistStage = { name: string; type: string; key?: string; dynamics?: any; exit_triggers?: any[]; limits?: any[] }
+type HistVar = { key: string; name: string; type: string; value: number }
+type HistEntry = {
+  id: string; time: number; name: string; file?: string;
+  profile?: { name?: string; final_weight?: number; temperature?: number; stages?: HistStage[]; variables?: HistVar[] };
+  data?: { shot?: { pressure?: number; flow?: number; weight?: number; gravimetric_flow?: number }; time?: number; profile_time?: number; status?: string }[];
+}
+
+export function computeRichLocalAnalysis(entry: HistEntry, profileName: string) {
+          // ── Helper functions (matching server analysis_service.py) ──
+
+          const _sf = (v: unknown, d = 0): number => {
+            if (v == null) return d
+            const n = Number(v)
+            return Number.isFinite(n) ? n : d
+          }
+          const _round1 = (v: number) => Math.round(v * 10) / 10
+
+          const _resolveVar = (val: unknown, vars: HistVar[]): number => {
+            if (typeof val === 'string' && val.startsWith('$')) {
+              const key = val.slice(1)
+              const v = vars.find(x => x.key === key)
+              return v ? _sf(v.value) : 0
+            }
+            return _sf(val)
+          }
+
+          const FLOW_IGNORE_WINDOW = 3.5
+          const PREINFUSION_KW = ['bloom', 'soak', 'preinfusion', 'pre-infusion', 'pre infusion', 'wet', 'fill', 'landing']
+
+          // ── Extract per-stage telemetry ──
+          const pts = entry.data ?? []
+          type StageStats = {
+            startTime: number; endTime: number; duration: number
+            startWeight: number; endWeight: number
+            startPressure: number; endPressure: number; avgPressure: number; maxPressure: number; minPressure: number
+            startFlow: number; endFlow: number; avgFlow: number; maxFlow: number
+          }
+          const shotStages = new Map<string, StageStats>()
+          {
+            let curStage: string | null = null
+            let stagePts: typeof pts = []
+            const flush = () => {
+              if (!curStage || stagePts.length === 0) return
+              const times = stagePts.map(p => (p.time ?? 0) / 1000)
+              const prs = stagePts.map(p => p.shot?.pressure ?? 0)
+              const wts = stagePts.map(p => p.shot?.weight ?? 0)
+              const fls = stagePts.map(p => p.shot?.flow ?? 0)
+              const flsFiltered = stagePts.filter(p => (p.time ?? 0) / 1000 >= FLOW_IGNORE_WINDOW).map(p => p.shot?.flow ?? 0)
+              const flowSrc = flsFiltered.length > 0 ? flsFiltered : fls
+              shotStages.set(curStage, {
+                startTime: Math.min(...times), endTime: Math.max(...times),
+                duration: Math.max(...times) - Math.min(...times),
+                startWeight: wts[0], endWeight: wts[wts.length - 1],
+                startPressure: prs[0], endPressure: prs[prs.length - 1],
+                avgPressure: prs.reduce((a, b) => a + b, 0) / prs.length,
+                maxPressure: Math.max(...prs), minPressure: Math.min(...prs),
+                startFlow: fls[0], endFlow: fls[fls.length - 1],
+                avgFlow: flowSrc.reduce((a, b) => a + b, 0) / flowSrc.length,
+                maxFlow: Math.max(...flowSrc),
+              })
+            }
+            for (const pt of pts) {
+              const st = (pt.status ?? '').trim()
+              if (!st || st.toLowerCase() === 'retracting') continue
+              if (st !== curStage) { flush(); curStage = st; stagePts = [] }
+              stagePts.push(pt)
+            }
+            flush()
+          }
+
+          // ── Overall metrics ──
+          let maxPressure = 0, maxFlow = 0
+          for (const pt of pts) {
+            if ((pt.shot?.pressure ?? 0) > maxPressure) maxPressure = pt.shot?.pressure ?? 0
+            const t = (pt.time ?? 0) / 1000
+            if (t >= FLOW_IGNORE_WINDOW && (pt.shot?.flow ?? 0) > maxFlow) maxFlow = pt.shot?.flow ?? 0
+          }
+          const lastPt = pts[pts.length - 1]
+          const finalWeight = lastPt?.shot?.weight ?? entry.profile?.final_weight ?? 0
+          const totalTime = lastPt ? (lastPt.profile_time ?? lastPt.time ?? 0) / 1000 : 0
+          const targetWeight = entry.profile?.final_weight ?? null
+
+          // ── Format helpers ──
+          const vars = entry.profile?.variables ?? []
+          const unitMap: Record<string, string> = { time: 's', weight: 'g', pressure: 'bar', flow: 'ml/s' }
+          const compMap: Record<string, string> = { '>=': '≥', '<=': '≤', '>': '>', '<': '<', '==': '=' }
+
+          const fmtDynamics = (stage: HistStage): string => {
+            const dp = stage.dynamics?.points ?? []
+            if (!dp.length) return `${stage.type} stage`
+            const unit = stage.type === 'pressure' ? 'bar' : 'ml/s'
+            if (dp.length === 1) {
+              const v = _resolveVar(dp[0][1] ?? dp[0][0], vars)
+              return `Constant ${stage.type} at ${v} ${unit}`
+            }
+            if (dp.length === 2) {
+              const sy = _resolveVar(dp[0][1], vars), ey = _resolveVar(dp[1][1], vars), ex = _sf(dp[1][0])
+              const ou = (stage.dynamics?.over ?? 'time') === 'time' ? 's' : 'g'
+              if (sy === ey) return `Constant ${stage.type} at ${sy} ${unit} for ${ex}${ou}`
+              const dir = ey > sy ? 'ramp up' : 'ramp down'
+              return `${stage.type[0].toUpperCase() + stage.type.slice(1)} ${dir} from ${sy} to ${ey} ${unit} over ${ex}${ou}`
+            }
+            const vals = dp.map((p: number[]) => _resolveVar(p[1], vars))
+            return `${stage.type[0].toUpperCase() + stage.type.slice(1)} curve: ${vals.join(' → ')} ${unit}`
+          }
+
+          const fmtTriggers = (triggers: any[]) => triggers.map((t: any) => {
+            const v = _resolveVar(t.value, vars)
+            const c = compMap[t.comparison] ?? t.comparison
+            const u = unitMap[t.type] ?? ''
+            return { type: t.type, value: v, comparison: t.comparison, description: `${t.type} ${c} ${v}${u}` }
+          })
+
+          const fmtLimits = (limits: any[]) => limits.map((l: any) => {
+            const v = _resolveVar(l.value, vars)
+            const u = unitMap[l.type] ?? ''
+            return { type: l.type, value: v, description: `Limit ${l.type} to ${v}${u}` }
+          })
+
+          // ── Stage analysis ──
+          const profileStages = entry.profile?.stages ?? []
+          const stageAnalyses: any[] = []
+          const unreachedStages: string[] = []
+          let preinfusionTime = 0
+          const preinfusionStages: string[] = []
+
+          for (const ps of profileStages) {
+            const stageName = (ps.name ?? '').trim()
+            const stageType = ps.type ?? 'unknown'
+            // Match shot stage by name (trimmed, case-insensitive)
+            let shotData: StageStats | undefined
+            for (const [k, v] of shotStages) {
+              if (k.trim().toLowerCase() === stageName.toLowerCase()) { shotData = v; break }
+            }
+
+            const profileTarget = fmtDynamics(ps)
+            const exitTriggers = fmtTriggers(ps.exit_triggers ?? [])
+            const limits = fmtLimits(ps.limits ?? [])
+            const executed = !!shotData
+
+            const stageResult: any = {
+              stage_name: stageName,
+              stage_key: (ps.key ?? stageName).toLowerCase().replace(/\s+/g, '_'),
+              stage_type: stageType,
+              profile_target: profileTarget,
+              exit_triggers: exitTriggers,
+              limits,
+              executed,
+              execution_data: null,
+              exit_trigger_result: null,
+              limit_hit: null,
+              assessment: null,
+            }
+
+            if (!executed) {
+              unreachedStages.push(stageName)
+              stageResult.assessment = { status: 'not_reached', message: 'This stage was never executed during the shot' }
+              stageAnalyses.push(stageResult)
+              continue
+            }
+
+            const sd = shotData!
+            const wGain = sd.endWeight - sd.startWeight
+            // Execution description
+            const descParts: string[] = []
+            const pDelta = sd.endPressure - sd.startPressure
+            if (Math.abs(pDelta) > 0.5) {
+              descParts.push(pDelta > 0
+                ? `Pressure rose from ${_round1(sd.startPressure)} to ${_round1(sd.endPressure)} bar`
+                : `Pressure declined from ${_round1(sd.startPressure)} to ${_round1(sd.endPressure)} bar`)
+            } else if (sd.maxPressure > 0) {
+              descParts.push(`Pressure held around ${_round1((sd.startPressure + sd.endPressure) / 2)} bar`)
+            }
+            const fDelta = sd.endFlow - sd.startFlow
+            if (Math.abs(fDelta) > 0.3) {
+              descParts.push(fDelta > 0
+                ? `Flow increased from ${_round1(sd.startFlow)} to ${_round1(sd.endFlow)} ml/s`
+                : `Flow decreased from ${_round1(sd.startFlow)} to ${_round1(sd.endFlow)} ml/s`)
+            } else if (sd.maxFlow > 0) {
+              descParts.push(`Flow steady at ${_round1((sd.startFlow + sd.endFlow) / 2)} ml/s`)
+            }
+            if (wGain > 1) descParts.push(`extracted ${_round1(wGain)}g`)
+            if (sd.duration > 0) descParts.push(`over ${_round1(sd.duration)}s`)
+            const execDesc = descParts.length > 0 ? descParts.join(', ').replace(/^./, c => c.toUpperCase()) : `Stage executed for ${_round1(sd.duration)}s`
+
+            stageResult.execution_data = {
+              duration: _round1(sd.duration), weight_gain: _round1(wGain),
+              start_weight: _round1(sd.startWeight), end_weight: _round1(sd.endWeight),
+              start_pressure: _round1(sd.startPressure), end_pressure: _round1(sd.endPressure),
+              avg_pressure: _round1(sd.avgPressure), max_pressure: _round1(sd.maxPressure), min_pressure: _round1(sd.minPressure),
+              start_flow: _round1(sd.startFlow), end_flow: _round1(sd.endFlow),
+              avg_flow: _round1(sd.avgFlow), max_flow: _round1(sd.maxFlow),
+              description: execDesc,
+            }
+
+            // Determine exit trigger hit
+            if (ps.exit_triggers?.length) {
+              let triggered: any = null
+              const notTriggered: any[] = []
+              for (const tr of ps.exit_triggers) {
+                const tType = tr.type ?? ''
+                const tVal = _resolveVar(tr.value, vars)
+                const comp = tr.comparison ?? '>='
+                let actual = 0
+                if (tType === 'time') actual = sd.duration
+                else if (tType === 'weight') actual = sd.endWeight
+                else if (tType === 'pressure') actual = comp === '>=' || comp === '>' ? sd.maxPressure : sd.endPressure
+                else if (tType === 'flow') actual = comp === '>=' || comp === '>' ? sd.maxFlow : sd.endFlow
+                const tol = (tType === 'time' || tType === 'weight') ? 0.5 : 0.2
+                let hit = false
+                if (comp === '>=') hit = actual >= tVal - tol
+                else if (comp === '>') hit = actual > tVal
+                else if (comp === '<=') hit = actual <= tVal + tol
+                else if (comp === '<') hit = actual < tVal
+                const u = unitMap[tType] ?? ''
+                const info = { type: tType, target: tVal, actual: _round1(actual), description: `${tType} >= ${tVal}${u}` }
+                if (hit && !triggered) triggered = info
+                else if (!hit) notTriggered.push(info)
+              }
+              stageResult.exit_trigger_result = { triggered, not_triggered: notTriggered }
+            }
+
+            // Limit hit check
+            for (const lim of (ps.limits ?? [])) {
+              const lType = lim.type ?? ''
+              const lVal = _resolveVar(lim.value, vars)
+              let actual = 0
+              if (lType === 'flow') actual = sd.maxFlow
+              else if (lType === 'pressure') actual = sd.maxPressure
+              else if (lType === 'time') actual = sd.duration
+              else if (lType === 'weight') actual = sd.endWeight
+              const u = unitMap[lType] ?? ''
+              if (actual >= lVal - 0.2) {
+                stageResult.limit_hit = { type: lType, limit_value: lVal, actual_value: _round1(actual), description: `Hit ${lType} limit of ${lVal}${u}` }
+                break
+              }
+            }
+
+            // Assessment
+            const etr = stageResult.exit_trigger_result
+            if (etr?.triggered) {
+              stageResult.assessment = stageResult.limit_hit
+                ? { status: 'hit_limit', message: `Stage exited but hit a limit (${stageResult.limit_hit.description})` }
+                : { status: 'reached_goal', message: `Exited via: ${etr.triggered.description}` }
+            } else if (etr && etr.not_triggered?.length) {
+              stageResult.assessment = { status: 'failed', message: 'Stage ended before exit triggers were satisfied' }
+            } else {
+              stageResult.assessment = { status: 'executed', message: 'Stage executed (no exit triggers defined)' }
+            }
+
+            stageAnalyses.push(stageResult)
+
+            // Pre-infusion tracking
+            const nl = stageName.toLowerCase()
+            if (PREINFUSION_KW.some(kw => nl.includes(kw))) {
+              preinfusionTime += sd.duration
+              preinfusionStages.push(stageName)
+            }
+          }
+
+          const preinfusionWeight = (() => {
+            let w = 0
+            for (const ps2 of profileStages) {
+              const sn = (ps2.name ?? '').trim().toLowerCase()
+              if (!PREINFUSION_KW.some(kw => sn.includes(kw))) continue
+              for (const [k, v] of shotStages) {
+                if (k.trim().toLowerCase() === sn) { w += Math.max(0, v.endWeight - v.startWeight); break }
+              }
+            }
+            return w
+          })()
+
+          const analysis = {
+            shot_summary: {
+              final_weight: _round1(finalWeight),
+              target_weight: targetWeight,
+              total_time: _round1(totalTime),
+              max_pressure: _round1(maxPressure),
+              max_flow: _round1(maxFlow),
+            },
+            weight_analysis: {
+              status: targetWeight
+                ? Math.abs(finalWeight - targetWeight) / targetWeight < 0.05 ? 'on_target'
+                  : finalWeight < targetWeight ? 'under' : 'over'
+                : 'on_target',
+              target: targetWeight,
+              actual: _round1(finalWeight),
+              deviation_percent: targetWeight
+                ? Math.round(((finalWeight - targetWeight) / targetWeight) * 1000) / 10
+                : 0,
+            },
+            stage_analyses: stageAnalyses,
+            unreached_stages: unreachedStages,
+            preinfusion_summary: {
+              stages: preinfusionStages,
+              total_time: _round1(preinfusionTime),
+              proportion_of_shot: totalTime > 0 ? _round1(preinfusionTime / totalTime * 100) : 0,
+              weight_accumulated: _round1(preinfusionWeight),
+              weight_percent_of_total: finalWeight > 0 ? _round1(preinfusionWeight / finalWeight * 100) : 0,
+              issues: [],
+              recommendations: [],
+            },
+            profile_info: {
+              name: profileName,
+              temperature: entry.profile?.temperature ?? null,
+              stage_count: profileStages.length,
+            },
+            profile_target_curves: (() => {
+              // Generate shot-aligned target curves from profile dynamics
+              if (!entry.profile) return []
+              const stageTimings = new Map<string, { startTime: number; endTime: number }>()
+              for (const [name, stats] of shotStages) {
+                stageTimings.set(name, { startTime: stats.startTime, endTime: stats.endTime })
+              }
+              return generateShotAlignedTargetCurves(
+                entry.profile as unknown as CachedProfile,
+                stageTimings,
+                pts as unknown as Array<Record<string, unknown>>,
+              )
+            })(),
+          }
+          ;(analysis as Record<string, unknown>).shot_facts = buildShotFacts(analysis as Parameters<typeof buildShotFacts>[0])
+
+  return analysis
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
 type ProfileFingerprint = {
   controlMode: 'pressure' | 'flow' | 'mixed' | 'unknown'
   techniqueTags: Set<string>
@@ -2518,12 +2847,12 @@ export function installDirectModeInterceptor(): void {
       const shotDate = decodeURIComponent(shotDataMatch[1])
       const shotFilename = decodeURIComponent(shotDataMatch[2])
       return (async () => {
-          type HistEntry = {
+          type HistDataEntry = {
             id: string; time: number; name: string; file?: string;
             profile?: { name?: string; id?: string; final_weight?: number; temperature?: number; author?: string; stages?: { name: string; type: string; key?: string }[] };
             data?: { shot?: { pressure?: number; flow?: number; weight?: number }; time?: number; profile_time?: number; sensors?: { external_1?: number } }[];
           }
-          const entry = await _findVisibleShot(shotDate, shotFilename) as HistEntry | null
+          const entry = await _findVisibleShot(shotDate, shotFilename) as HistDataEntry | null
           if (!entry) return jsonResponse({ detail: 'Shot not found' }, 404)
           const pts = entry.data ?? []
           const timeArr: number[] = []
@@ -2619,332 +2948,10 @@ export function installDirectModeInterceptor(): void {
           const shotFilename = (body.get('shot_filename') as string) || ''
           const profileName = (body.get('profile_name') as string) || 'Unknown'
 
-          /* eslint-disable @typescript-eslint/no-explicit-any */
-          type HistStage = { name: string; type: string; key?: string; dynamics?: any; exit_triggers?: any[]; limits?: any[] }
-          type HistVar = { key: string; name: string; type: string; value: number }
-          type HistEntry = {
-            id: string; time: number; name: string; file?: string;
-            profile?: { name?: string; final_weight?: number; temperature?: number; stages?: HistStage[]; variables?: HistVar[] };
-            data?: { shot?: { pressure?: number; flow?: number; weight?: number; gravimetric_flow?: number }; time?: number; profile_time?: number; status?: string }[];
-          }
-          /* eslint-enable @typescript-eslint/no-explicit-any */
           const entry = await _findVisibleShot(shotDate, shotFilename) as HistEntry | null
           if (!entry) return jsonResponse({ status: 'error', message: 'Shot not found' })
 
-          // ── Helper functions (matching server analysis_service.py) ──
-
-          const _sf = (v: unknown, d = 0): number => {
-            if (v == null) return d
-            const n = Number(v)
-            return Number.isFinite(n) ? n : d
-          }
-          const _round1 = (v: number) => Math.round(v * 10) / 10
-
-          const _resolveVar = (val: unknown, vars: HistVar[]): number => {
-            if (typeof val === 'string' && val.startsWith('$')) {
-              const key = val.slice(1)
-              const v = vars.find(x => x.key === key)
-              return v ? _sf(v.value) : 0
-            }
-            return _sf(val)
-          }
-
-          const FLOW_IGNORE_WINDOW = 3.5
-          const PREINFUSION_KW = ['bloom', 'soak', 'preinfusion', 'pre-infusion', 'pre infusion', 'wet', 'fill', 'landing']
-
-          // ── Extract per-stage telemetry ──
-          const pts = entry.data ?? []
-          type StageStats = {
-            startTime: number; endTime: number; duration: number
-            startWeight: number; endWeight: number
-            startPressure: number; endPressure: number; avgPressure: number; maxPressure: number; minPressure: number
-            startFlow: number; endFlow: number; avgFlow: number; maxFlow: number
-          }
-          const shotStages = new Map<string, StageStats>()
-          {
-            let curStage: string | null = null
-            let stagePts: typeof pts = []
-            const flush = () => {
-              if (!curStage || stagePts.length === 0) return
-              const times = stagePts.map(p => (p.time ?? 0) / 1000)
-              const prs = stagePts.map(p => p.shot?.pressure ?? 0)
-              const wts = stagePts.map(p => p.shot?.weight ?? 0)
-              const fls = stagePts.map(p => p.shot?.flow ?? 0)
-              const flsFiltered = stagePts.filter(p => (p.time ?? 0) / 1000 >= FLOW_IGNORE_WINDOW).map(p => p.shot?.flow ?? 0)
-              const flowSrc = flsFiltered.length > 0 ? flsFiltered : fls
-              shotStages.set(curStage, {
-                startTime: Math.min(...times), endTime: Math.max(...times),
-                duration: Math.max(...times) - Math.min(...times),
-                startWeight: wts[0], endWeight: wts[wts.length - 1],
-                startPressure: prs[0], endPressure: prs[prs.length - 1],
-                avgPressure: prs.reduce((a, b) => a + b, 0) / prs.length,
-                maxPressure: Math.max(...prs), minPressure: Math.min(...prs),
-                startFlow: fls[0], endFlow: fls[fls.length - 1],
-                avgFlow: flowSrc.reduce((a, b) => a + b, 0) / flowSrc.length,
-                maxFlow: Math.max(...flowSrc),
-              })
-            }
-            for (const pt of pts) {
-              const st = (pt.status ?? '').trim()
-              if (!st || st.toLowerCase() === 'retracting') continue
-              if (st !== curStage) { flush(); curStage = st; stagePts = [] }
-              stagePts.push(pt)
-            }
-            flush()
-          }
-
-          // ── Overall metrics ──
-          let maxPressure = 0, maxFlow = 0
-          for (const pt of pts) {
-            if ((pt.shot?.pressure ?? 0) > maxPressure) maxPressure = pt.shot?.pressure ?? 0
-            const t = (pt.time ?? 0) / 1000
-            if (t >= FLOW_IGNORE_WINDOW && (pt.shot?.flow ?? 0) > maxFlow) maxFlow = pt.shot?.flow ?? 0
-          }
-          const lastPt = pts[pts.length - 1]
-          const finalWeight = lastPt?.shot?.weight ?? entry.profile?.final_weight ?? 0
-          const totalTime = lastPt ? (lastPt.profile_time ?? lastPt.time ?? 0) / 1000 : 0
-          const targetWeight = entry.profile?.final_weight ?? null
-
-          // ── Format helpers ──
-          const vars = entry.profile?.variables ?? []
-          const unitMap: Record<string, string> = { time: 's', weight: 'g', pressure: 'bar', flow: 'ml/s' }
-          const compMap: Record<string, string> = { '>=': '≥', '<=': '≤', '>': '>', '<': '<', '==': '=' }
-
-          const fmtDynamics = (stage: HistStage): string => {
-            const dp = stage.dynamics?.points ?? []
-            if (!dp.length) return `${stage.type} stage`
-            const unit = stage.type === 'pressure' ? 'bar' : 'ml/s'
-            if (dp.length === 1) {
-              const v = _resolveVar(dp[0][1] ?? dp[0][0], vars)
-              return `Constant ${stage.type} at ${v} ${unit}`
-            }
-            if (dp.length === 2) {
-              const sy = _resolveVar(dp[0][1], vars), ey = _resolveVar(dp[1][1], vars), ex = _sf(dp[1][0])
-              const ou = (stage.dynamics?.over ?? 'time') === 'time' ? 's' : 'g'
-              if (sy === ey) return `Constant ${stage.type} at ${sy} ${unit} for ${ex}${ou}`
-              const dir = ey > sy ? 'ramp up' : 'ramp down'
-              return `${stage.type[0].toUpperCase() + stage.type.slice(1)} ${dir} from ${sy} to ${ey} ${unit} over ${ex}${ou}`
-            }
-            const vals = dp.map((p: number[]) => _resolveVar(p[1], vars))
-            return `${stage.type[0].toUpperCase() + stage.type.slice(1)} curve: ${vals.join(' → ')} ${unit}`
-          }
-
-          const fmtTriggers = (triggers: any[]) => triggers.map((t: any) => {
-            const v = _resolveVar(t.value, vars)
-            const c = compMap[t.comparison] ?? t.comparison
-            const u = unitMap[t.type] ?? ''
-            return { type: t.type, value: v, comparison: t.comparison, description: `${t.type} ${c} ${v}${u}` }
-          })
-
-          const fmtLimits = (limits: any[]) => limits.map((l: any) => {
-            const v = _resolveVar(l.value, vars)
-            const u = unitMap[l.type] ?? ''
-            return { type: l.type, value: v, description: `Limit ${l.type} to ${v}${u}` }
-          })
-
-          // ── Stage analysis ──
-          const profileStages = entry.profile?.stages ?? []
-          const stageAnalyses: any[] = []
-          const unreachedStages: string[] = []
-          let preinfusionTime = 0
-          const preinfusionStages: string[] = []
-
-          for (const ps of profileStages) {
-            const stageName = (ps.name ?? '').trim()
-            const stageType = ps.type ?? 'unknown'
-            // Match shot stage by name (trimmed, case-insensitive)
-            let shotData: StageStats | undefined
-            for (const [k, v] of shotStages) {
-              if (k.trim().toLowerCase() === stageName.toLowerCase()) { shotData = v; break }
-            }
-
-            const profileTarget = fmtDynamics(ps)
-            const exitTriggers = fmtTriggers(ps.exit_triggers ?? [])
-            const limits = fmtLimits(ps.limits ?? [])
-            const executed = !!shotData
-
-            const stageResult: any = {
-              stage_name: stageName,
-              stage_key: (ps.key ?? stageName).toLowerCase().replace(/\s+/g, '_'),
-              stage_type: stageType,
-              profile_target: profileTarget,
-              exit_triggers: exitTriggers,
-              limits,
-              executed,
-              execution_data: null,
-              exit_trigger_result: null,
-              limit_hit: null,
-              assessment: null,
-            }
-
-            if (!executed) {
-              unreachedStages.push(stageName)
-              stageResult.assessment = { status: 'not_reached', message: 'This stage was never executed during the shot' }
-              stageAnalyses.push(stageResult)
-              continue
-            }
-
-            const sd = shotData!
-            const wGain = sd.endWeight - sd.startWeight
-            // Execution description
-            const descParts: string[] = []
-            const pDelta = sd.endPressure - sd.startPressure
-            if (Math.abs(pDelta) > 0.5) {
-              descParts.push(pDelta > 0
-                ? `Pressure rose from ${_round1(sd.startPressure)} to ${_round1(sd.endPressure)} bar`
-                : `Pressure declined from ${_round1(sd.startPressure)} to ${_round1(sd.endPressure)} bar`)
-            } else if (sd.maxPressure > 0) {
-              descParts.push(`Pressure held around ${_round1((sd.startPressure + sd.endPressure) / 2)} bar`)
-            }
-            const fDelta = sd.endFlow - sd.startFlow
-            if (Math.abs(fDelta) > 0.3) {
-              descParts.push(fDelta > 0
-                ? `Flow increased from ${_round1(sd.startFlow)} to ${_round1(sd.endFlow)} ml/s`
-                : `Flow decreased from ${_round1(sd.startFlow)} to ${_round1(sd.endFlow)} ml/s`)
-            } else if (sd.maxFlow > 0) {
-              descParts.push(`Flow steady at ${_round1((sd.startFlow + sd.endFlow) / 2)} ml/s`)
-            }
-            if (wGain > 1) descParts.push(`extracted ${_round1(wGain)}g`)
-            if (sd.duration > 0) descParts.push(`over ${_round1(sd.duration)}s`)
-            const execDesc = descParts.length > 0 ? descParts.join(', ').replace(/^./, c => c.toUpperCase()) : `Stage executed for ${_round1(sd.duration)}s`
-
-            stageResult.execution_data = {
-              duration: _round1(sd.duration), weight_gain: _round1(wGain),
-              start_weight: _round1(sd.startWeight), end_weight: _round1(sd.endWeight),
-              start_pressure: _round1(sd.startPressure), end_pressure: _round1(sd.endPressure),
-              avg_pressure: _round1(sd.avgPressure), max_pressure: _round1(sd.maxPressure), min_pressure: _round1(sd.minPressure),
-              start_flow: _round1(sd.startFlow), end_flow: _round1(sd.endFlow),
-              avg_flow: _round1(sd.avgFlow), max_flow: _round1(sd.maxFlow),
-              description: execDesc,
-            }
-
-            // Determine exit trigger hit
-            if (ps.exit_triggers?.length) {
-              let triggered: any = null
-              const notTriggered: any[] = []
-              for (const tr of ps.exit_triggers) {
-                const tType = tr.type ?? ''
-                const tVal = _resolveVar(tr.value, vars)
-                const comp = tr.comparison ?? '>='
-                let actual = 0
-                if (tType === 'time') actual = sd.duration
-                else if (tType === 'weight') actual = sd.endWeight
-                else if (tType === 'pressure') actual = comp === '>=' || comp === '>' ? sd.maxPressure : sd.endPressure
-                else if (tType === 'flow') actual = comp === '>=' || comp === '>' ? sd.maxFlow : sd.endFlow
-                const tol = (tType === 'time' || tType === 'weight') ? 0.5 : 0.2
-                let hit = false
-                if (comp === '>=') hit = actual >= tVal - tol
-                else if (comp === '>') hit = actual > tVal
-                else if (comp === '<=') hit = actual <= tVal + tol
-                else if (comp === '<') hit = actual < tVal
-                const u = unitMap[tType] ?? ''
-                const info = { type: tType, target: tVal, actual: _round1(actual), description: `${tType} >= ${tVal}${u}` }
-                if (hit && !triggered) triggered = info
-                else if (!hit) notTriggered.push(info)
-              }
-              stageResult.exit_trigger_result = { triggered, not_triggered: notTriggered }
-            }
-
-            // Limit hit check
-            for (const lim of (ps.limits ?? [])) {
-              const lType = lim.type ?? ''
-              const lVal = _resolveVar(lim.value, vars)
-              let actual = 0
-              if (lType === 'flow') actual = sd.maxFlow
-              else if (lType === 'pressure') actual = sd.maxPressure
-              else if (lType === 'time') actual = sd.duration
-              else if (lType === 'weight') actual = sd.endWeight
-              const u = unitMap[lType] ?? ''
-              if (actual >= lVal - 0.2) {
-                stageResult.limit_hit = { type: lType, limit_value: lVal, actual_value: _round1(actual), description: `Hit ${lType} limit of ${lVal}${u}` }
-                break
-              }
-            }
-
-            // Assessment
-            const etr = stageResult.exit_trigger_result
-            if (etr?.triggered) {
-              stageResult.assessment = stageResult.limit_hit
-                ? { status: 'hit_limit', message: `Stage exited but hit a limit (${stageResult.limit_hit.description})` }
-                : { status: 'reached_goal', message: `Exited via: ${etr.triggered.description}` }
-            } else if (etr && etr.not_triggered?.length) {
-              stageResult.assessment = { status: 'failed', message: 'Stage ended before exit triggers were satisfied' }
-            } else {
-              stageResult.assessment = { status: 'executed', message: 'Stage executed (no exit triggers defined)' }
-            }
-
-            stageAnalyses.push(stageResult)
-
-            // Pre-infusion tracking
-            const nl = stageName.toLowerCase()
-            if (PREINFUSION_KW.some(kw => nl.includes(kw))) {
-              preinfusionTime += sd.duration
-              preinfusionStages.push(stageName)
-            }
-          }
-
-          const preinfusionWeight = (() => {
-            let w = 0
-            for (const ps2 of profileStages) {
-              const sn = (ps2.name ?? '').trim().toLowerCase()
-              if (!PREINFUSION_KW.some(kw => sn.includes(kw))) continue
-              for (const [k, v] of shotStages) {
-                if (k.trim().toLowerCase() === sn) { w += Math.max(0, v.endWeight - v.startWeight); break }
-              }
-            }
-            return w
-          })()
-
-          const analysis = {
-            shot_summary: {
-              final_weight: _round1(finalWeight),
-              target_weight: targetWeight,
-              total_time: _round1(totalTime),
-              max_pressure: _round1(maxPressure),
-              max_flow: _round1(maxFlow),
-            },
-            weight_analysis: {
-              status: targetWeight
-                ? Math.abs(finalWeight - targetWeight) / targetWeight < 0.05 ? 'on_target'
-                  : finalWeight < targetWeight ? 'under' : 'over'
-                : 'on_target',
-              target: targetWeight,
-              actual: _round1(finalWeight),
-              deviation_percent: targetWeight
-                ? Math.round(((finalWeight - targetWeight) / targetWeight) * 1000) / 10
-                : 0,
-            },
-            stage_analyses: stageAnalyses,
-            unreached_stages: unreachedStages,
-            preinfusion_summary: {
-              stages: preinfusionStages,
-              total_time: _round1(preinfusionTime),
-              proportion_of_shot: totalTime > 0 ? _round1(preinfusionTime / totalTime * 100) : 0,
-              weight_accumulated: _round1(preinfusionWeight),
-              weight_percent_of_total: finalWeight > 0 ? _round1(preinfusionWeight / finalWeight * 100) : 0,
-              issues: [],
-              recommendations: [],
-            },
-            profile_info: {
-              name: profileName,
-              temperature: entry.profile?.temperature ?? null,
-              stage_count: profileStages.length,
-            },
-            profile_target_curves: (() => {
-              // Generate shot-aligned target curves from profile dynamics
-              if (!entry.profile) return []
-              const stageTimings = new Map<string, { startTime: number; endTime: number }>()
-              for (const [name, stats] of shotStages) {
-                stageTimings.set(name, { startTime: stats.startTime, endTime: stats.endTime })
-              }
-              return generateShotAlignedTargetCurves(
-                entry.profile as unknown as CachedProfile,
-                stageTimings,
-                pts as unknown as Array<Record<string, unknown>>,
-              )
-            })(),
-          }
-          ;(analysis as Record<string, unknown>).shot_facts = buildShotFacts(analysis as Parameters<typeof buildShotFacts>[0])
+          const analysis = computeRichLocalAnalysis(entry, profileName)
           return jsonResponse({ status: 'success', analysis })
         } catch (err) {
           const msg = err instanceof Error ? err.message : 'Analysis failed'
@@ -2974,102 +2981,10 @@ export function installDirectModeInterceptor(): void {
           } | null
           if (!entry) return jsonResponse({ status: 'error', message: 'Shot not found' })
 
-          // 2. Compute shot summary metrics directly from shot data
+          // 2. Build the rich, server-shaped local analysis (parity with /analyze) for shot facts
           const pts = entry.data ?? []
           if (!pts.length) return jsonResponse({ status: 'error', message: 'Shot has no telemetry data' })
-          let totalTime = 0
-          let finalWeight = 0
-          let maxPressure = 0
-          let maxFlow = 0
-          const targetWeight = entry.profile?.final_weight ?? null
-          // Stage-level stats
-          type ShotStageInfo = { name: string; duration: number; avgPressure: number; avgFlow: number; weightGain: number; endWeight: number }
-          const stageInfos: ShotStageInfo[] = []
-          {
-            let curStage: string | null = null
-            let stageStart = 0
-            let pressureSum = 0
-            let flowSum = 0
-            let count = 0
-            let stageStartWeight = 0
-            const flushStage = (endTime: number, endWeight2: number) => {
-              if (!curStage || count === 0) return
-              stageInfos.push({
-                name: curStage,
-                duration: Math.round((endTime - stageStart) * 10) / 10,
-                avgPressure: Math.round(pressureSum / count * 10) / 10,
-                avgFlow: Math.round(flowSum / count * 10) / 10,
-                weightGain: Math.round((endWeight2 - stageStartWeight) * 10) / 10,
-                endWeight: Math.round(endWeight2 * 10) / 10,
-              })
-            }
-            for (const pt of pts) {
-              const status = String((pt as Record<string, unknown>).status ?? '').trim()
-              if (!status || status.toLowerCase() === 'retracting') continue
-              const timeSec = safeNumber((pt as Record<string, unknown>).profile_time ?? (pt as Record<string, unknown>).time) / 1000
-              const shot = ((pt as Record<string, Record<string, unknown>>).shot ?? {})
-              const p = safeNumber(shot.pressure)
-              const f = safeNumber(shot.flow) || safeNumber(shot.gravimetric_flow)
-              const w = safeNumber(shot.weight)
-              if (status !== curStage) {
-                flushStage(timeSec, finalWeight)
-                curStage = status
-                stageStart = timeSec
-                pressureSum = 0
-                flowSum = 0
-                count = 0
-                stageStartWeight = w
-              }
-              pressureSum += p
-              flowSum += f
-              count++
-              if (p > maxPressure) maxPressure = p
-              if (f > maxFlow) maxFlow = f
-              finalWeight = w
-              totalTime = timeSec
-            }
-            flushStage(totalTime, finalWeight)
-          }
-
-          // Use the actual settled final telemetry sample (including drip during piston retraction)
-          // so both time and weight reflect the same end-of-shot point as getHistoryMetrics()
-          const lastRawPt = (pts[pts.length - 1] ?? {}) as Record<string, unknown>
-          const lastShot = ((lastRawPt.shot as Record<string, unknown> | undefined) ?? {})
-          const actualFinalWeight = safeNumber(lastShot.weight) || finalWeight
-          const actualTotalTime = safeNumber(lastRawPt.profile_time ?? lastRawPt.time) / 1000 || totalTime
-
-          // If there was weight gain during retraction, add a synthetic drip stage so the AI
-          // sees how the gap between the last active stage and final_weight_g was filled
-          const dripWeight = Math.round((actualFinalWeight - finalWeight) * 10) / 10
-          if (dripWeight > 0.1) {
-            stageInfos.push({
-              name: 'Drip (post-retraction)',
-              duration: Math.round((actualTotalTime - totalTime) * 10) / 10,
-              avgPressure: 0,
-              avgFlow: 0,
-              weightGain: dripWeight,
-              endWeight: Math.round(actualFinalWeight * 10) / 10,
-            })
-          }
-
-          const localAnalysis = {
-            shot_summary: {
-              total_time_s: Math.round(actualTotalTime * 10) / 10,
-              final_weight_g: Math.round(actualFinalWeight * 10) / 10,
-              target_weight_g: targetWeight,
-              weight_deviation_pct: targetWeight ? Math.round(((actualFinalWeight - targetWeight) / targetWeight) * 1000) / 10 : 0,
-              max_pressure_bar: Math.round(maxPressure * 10) / 10,
-              max_flow_mls: Math.round(maxFlow * 10) / 10,
-            },
-            stages: stageInfos.map(s => ({
-              name: s.name,
-              duration_s: s.duration,
-              avg_pressure: s.avgPressure,
-              avg_flow: s.avgFlow,
-              weight_gain: s.weightGain,
-              cumulative_weight_at_end: s.endWeight,
-            })),
-          }
+          const richAnalysis = computeRichLocalAnalysis(entry as unknown as HistEntry, pName)
 
           // 3. Build profile context
           const shotProfile = entry.profile
@@ -3123,7 +3038,7 @@ export function installDirectModeInterceptor(): void {
             profileDescription: profileDescription ?? '',
             profileVars,
             cleanStages,
-            facts: buildShotFacts(localAnalysis as Parameters<typeof buildShotFacts>[0]),
+            facts: buildShotFacts(richAnalysis as Parameters<typeof buildShotFacts>[0]),
             tasteContext,
             graphSamples,
           })

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -9,6 +9,8 @@ import { deriveStructuralTags } from '@/lib/profileAnalysis'
 import type { AnalyzableProfile } from '@/lib/profileAnalysis'
 import { AI_TAGS_PROMPT, parseAiTags, stripTagsLine } from '@/lib/tags'
 import { buildShotFacts } from '@/lib/shotFacts'
+import { buildAnalyzeLlmPrompt } from './analyzeLlmPrompt'
+import { buildTasteContext } from '../ai/prompts'
 import {
   addDirectDialInIteration,
   clearDirectHistory,
@@ -3106,125 +3108,25 @@ export function installDirectModeInterceptor(): void {
           }
 
           // 5. Build the comprehensive prompt (matching server format)
-          const prompt = `You are an expert espresso barista and profiling specialist analyzing a shot from a Meticulous Espresso Machine.
+          const tasteX = body.get('taste_x') != null ? Number(body.get('taste_x')) : null
+          const tasteY = body.get('taste_y') != null ? Number(body.get('taste_y')) : null
+          const tasteDescriptors = String(body.get('taste_descriptors') ?? '')
+            .split(',').map(s => s.trim()).filter(Boolean)
+          const tasteContext = (tasteX != null && tasteY != null)
+            ? buildTasteContext(tasteX, tasteY, tasteDescriptors)
+            : ''
 
-## Profile Being Used
-Name: ${pName}
-Temperature: ${shotProfile?.temperature ?? 'Not set'}°C
-Target Weight: ${shotProfile?.final_weight ?? 'Not set'}g
-
-### Profile Description
-${profileDescription || 'No description provided - analyze the profile structure to understand intent.'}
-
-### Profile Variables
-${JSON.stringify(profileVars, null, 2)}
-
-### Profile Stages
-${JSON.stringify(cleanStages, null, 2)}
-
-## Full Local Analysis
-This is the complete algorithmic analysis of the shot. Use this data to inform your expert analysis.
-
-IMPORTANT: Each stage includes 'cumulative_weight_at_end' which shows the total weight when that stage ended.
-If a stage ended early but the cumulative weight was near the target weight, the shot likely terminated
-correctly due to reaching the final weight target - this is NORMAL and EXPECTED behavior.
-A stage that appears "short" may simply mean the target yield was reached, which is the correct outcome.
-
-IMPORTANT: The 'final_weight_g' in shot_summary is the actual settled weight AFTER the machine's piston retraction completes.
-The Meticulous machine issues a stop signal BEFORE the target weight is reached, accounting for residual flow that will drip
-into the cup during piston retraction. This means the final weight accurately reflects the total liquid in the cup.
-Do NOT penalize the shot for weight deviation unless 'weight_deviation_pct' exceeds ±5%.
-
-${JSON.stringify(localAnalysis, null, 2)}
-
-### Graph Sample Points
-${JSON.stringify(graphSamples, null, 2)}
-
----
-
-Based on this data, provide a detailed expert analysis.
-
-CRITICAL FORMATTING RULES:
-1. You MUST use EXACTLY these 5 section headers with the exact format shown (## followed by number, period, space, then title)
-2. Each section MUST have the subsection headers shown (bold text with colon, like **What Happened:**)
-3. ALL content under subsections MUST be bullet points starting with "- "
-4. Keep bullet points concise (1-2 sentences max per bullet)
-5. Do NOT add extra sections or subsections beyond what's specified
-
-## 1. Shot Performance
-
-**What Happened:**
-- [Stage-by-stage description of the extraction]
-- [Notable events: pressure spikes, flow restrictions, early/late stage exits]
-- [Final weight accuracy relative to target]
-
-**Assessment:** [Choose exactly one: Good / Acceptable / Needs Improvement / Problematic]
-
-## 2. Root Cause Analysis
-
-**Primary Factors:**
-- [Most likely cause with brief explanation]
-- [Second most likely cause if applicable]
-
-**Secondary Considerations:**
-- [Other contributing factors]
-- [Environmental or equipment factors if relevant]
-
-## 3. Setup Recommendations
-
-**Priority Changes:**
-- [Most important change - be specific with numbers when possible]
-- [Second priority change]
-
-**Additional Suggestions:**
-- [Other tweaks to consider]
-
-## 4. Profile Recommendations
-
-**Recommended Adjustments:**
-- [Specific profile changes: timing, triggers, targets]
-- [Variable value changes if applicable]
-
-**Reasoning:**
-- [Why these changes would improve the shot]
-
-## 5. Profile Design Observations
-
-**Strengths:**
-- [Well-designed aspects of this profile]
-
-**Potential Improvements:**
-- [Exit trigger or safety limit suggestions]
-- [Robustness improvements]
-
-Focus on actionable insights. Be specific with numbers where possible (e.g., "grind 1-2 steps finer" not just "grind finer").
-
-## Structured Recommendations (MANDATORY)
-
-After your analysis sections, you MUST output a structured JSON block with specific, actionable profile variable recommendations.
-Use EXACTLY this format — the markers are parsed programmatically:
-
-RECOMMENDATIONS_JSON:
-[
-  {
-    "variable": "<variable key from the profile, e.g. 'pressure', 'temperature'>",
-    "current_value": <current numeric value>,
-    "recommended_value": <suggested numeric value>,
-    "stage": "<stage name this applies to, or 'global' for top-level settings>",
-    "confidence": "<high|medium|low>",
-    "reason": "<one-sentence explanation>"
-  }
-]
-END_RECOMMENDATIONS_JSON
-
-Rules for recommendations:
-- Only include recommendations where you have a SPECIFIC numeric change to suggest
-- Use actual variable keys from the Profile Variables section above
-- For top-level settings (temperature, final_weight), use stage="global"
-- For stage-specific changes, use the stage name from Profile Stages
-- confidence: "high" = strong evidence from data, "medium" = likely beneficial, "low" = worth trying
-- If no recommendations apply, output an empty array: RECOMMENDATIONS_JSON:\n[]\nEND_RECOMMENDATIONS_JSON
-`
+          const prompt = buildAnalyzeLlmPrompt({
+            profileName: pName,
+            temperature: shotProfile?.temperature ?? null,
+            targetWeight: shotProfile?.final_weight ?? null,
+            profileDescription: profileDescription ?? '',
+            profileVars,
+            cleanStages,
+            facts: buildShotFacts(localAnalysis as Parameters<typeof buildShotFacts>[0]),
+            tasteContext,
+            graphSamples,
+          })
 
           // 6. Call the AI provider for shot analysis (with retry on transient errors)
           if (!isAIConfigured()) {

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -9,7 +9,7 @@ import { deriveStructuralTags } from '@/lib/profileAnalysis'
 import type { AnalyzableProfile } from '@/lib/profileAnalysis'
 import { AI_TAGS_PROMPT, parseAiTags, stripTagsLine } from '@/lib/tags'
 import { buildShotFacts } from '@/lib/shotFacts'
-import { lintShotAnalysis, repairShotAnalysis, validateAgainstFacts } from '@/lib/analysisLint'
+import { lintShotAnalysis, repairShotAnalysis, validateAgainstFacts, checkStructure } from '@/lib/analysisLint'
 import { buildAnalyzeLlmPrompt } from './analyzeLlmPrompt'
 import { buildTasteContext } from '../ai/prompts'
 import {
@@ -3057,14 +3057,13 @@ export function installDirectModeInterceptor(): void {
             return r.text ?? ''
           }
           let analysisText = await gen()
-          let lint = lintShotAnalysis(analysisText)
-          let factCheck = validateAgainstFacts(analysisText, facts)
-          if (!lint.valid || !factCheck.valid) {
-            analysisText = await gen()  // one retry
-            lint = lintShotAnalysis(analysisText)
-            factCheck = validateAgainstFacts(analysisText, facts)
+          const ok = (txt: string) =>
+            lintShotAnalysis(txt).valid && validateAgainstFacts(txt, facts).valid && checkStructure(txt).valid
+          if (!ok(analysisText)) {
+            const retry = await gen()
+            if (ok(retry)) analysisText = retry
           }
-          if (!lint.valid) analysisText = repairShotAnalysis(analysisText)
+          if (!lintShotAnalysis(analysisText).valid) analysisText = repairShotAnalysis(analysisText)
           return jsonResponse({
             status: 'success',
             llm_analysis: analysisText,

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -3034,31 +3034,7 @@ export function installDirectModeInterceptor(): void {
             limits: s.limits,
           }))
 
-          // 4. Sample key data points from the shot for graph context
-          const dataEntries = entry.data ?? []
-          const graphSamples: Array<Record<string, unknown>> = []
-          if (dataEntries.length > 0) {
-            const indices = [0]
-            const n = dataEntries.length
-            for (const pct of [0.25, 0.5, 0.75]) {
-              const idx = Math.floor(n * pct)
-              if (!indices.includes(idx)) indices.push(idx)
-            }
-            indices.push(n - 1)
-            for (const idx of [...new Set(indices)].sort((a, b) => a - b)) {
-              const e = dataEntries[idx] as Record<string, unknown>
-              const shot = (e.shot ?? {}) as Record<string, unknown>
-              graphSamples.push({
-                time_s: Math.round(safeNumber(e.profile_time ?? e.time) / 100) / 10,
-                pressure: Math.round(safeNumber(shot.pressure) * 10) / 10,
-                flow: Math.round((safeNumber(shot.flow) || safeNumber(shot.gravimetric_flow)) * 10) / 10,
-                weight: Math.round(safeNumber(shot.weight) * 10) / 10,
-                stage: String(e.status ?? ''),
-              })
-            }
-          }
-
-          // 5. Build the comprehensive prompt (matching server format)
+          // 4. Build the comprehensive prompt
           const tasteX = body.get('taste_x') != null ? Number(body.get('taste_x')) : null
           const tasteY = body.get('taste_y') != null ? Number(body.get('taste_y')) : null
           const tasteDescriptors = String(body.get('taste_descriptors') ?? '')
@@ -3077,10 +3053,9 @@ export function installDirectModeInterceptor(): void {
             cleanStages,
             facts,
             tasteContext,
-            graphSamples,
           })
 
-          // 6. Call the AI provider for shot analysis (with retry on transient errors)
+          // 5. Call the AI provider for shot analysis (with retry on transient errors)
           if (!isAIConfigured()) {
             return jsonResponse({ status: 'error', message: aiNotConfiguredMessage() })
           }

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -388,6 +388,36 @@ function resolveProfileValue(value: unknown, variables: Array<Record<string, unk
 }
 
 /**
+ * Mean of a pressure/flow stage's resolved dynamics setpoints — the intended
+ * scalar target (bar or ml/s) consumed by shotFacts.curveAdherence. Returns
+ * null for non-pressure/flow stages or when no numeric setpoints exist.
+ * Mirror of the server analysis_service._mean_dynamics_target — keep in sync.
+ */
+function meanDynamicsTarget(
+  stageType: string,
+  points: unknown,
+  variables: Array<Record<string, unknown>>,
+): number | null {
+  if (stageType !== 'pressure' && stageType !== 'flow') return null
+  if (!Array.isArray(points)) return null
+  const values: number[] = []
+  for (const point of points) {
+    if (!Array.isArray(point) || point.length === 0) continue
+    const raw = point.length > 1 ? point[1] : point[0]
+    let resolved: unknown = raw
+    if (typeof raw === 'string' && raw.startsWith('$')) {
+      const key = raw.slice(1)
+      const variable = variables.find((item) => item.key === key || item.name === key)
+      resolved = variable?.value
+    }
+    const num = typeof resolved === 'number' ? resolved : Number(resolved)
+    if (Number.isFinite(num)) values.push(num)
+  }
+  if (values.length === 0) return null
+  return Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 100) / 100
+}
+
+/**
  * Build target-curve points for a time-based, multi-point stage.
  *
  * Dynamics point x-values are absolute seconds measured from the start of the
@@ -766,6 +796,11 @@ export function computeRichLocalAnalysis(entry: HistEntry, profileName: string) 
               stage_key: (ps.key ?? stageName).toLowerCase().replace(/\s+/g, '_'),
               stage_type: stageType,
               profile_target: profileTarget,
+              profile_target_value: meanDynamicsTarget(
+                stageType,
+                ps.dynamics?.points,
+                vars as Array<Record<string, unknown>>,
+              ),
               exit_triggers: exitTriggers,
               limits,
               executed,

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -8,6 +8,7 @@ import { getDirectRequestContext, isMeticAIProxyApiPath, jsonResponse } from './
 import { deriveStructuralTags } from '@/lib/profileAnalysis'
 import type { AnalyzableProfile } from '@/lib/profileAnalysis'
 import { AI_TAGS_PROMPT, parseAiTags, stripTagsLine } from '@/lib/tags'
+import { buildShotFacts } from '@/lib/shotFacts'
 import {
   addDirectDialInIteration,
   clearDirectHistory,
@@ -2941,6 +2942,7 @@ export function installDirectModeInterceptor(): void {
               )
             })(),
           }
+          ;(analysis as Record<string, unknown>).shot_facts = buildShotFacts(analysis as Parameters<typeof buildShotFacts>[0])
           return jsonResponse({ status: 'success', analysis })
         } catch (err) {
           const msg = err instanceof Error ? err.message : 'Analysis failed'

--- a/apps/web/src/services/interceptor/analyzeLlmPrompt.test.ts
+++ b/apps/web/src/services/interceptor/analyzeLlmPrompt.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { buildAnalyzeLlmPrompt } from './analyzeLlmPrompt'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+const facts: ShotFacts = {
+  stages: [{ stage_name: 'Hold', reached: true, control_mode: 'pressure', trigger_type: 'weight',
+    trigger_class: { kind: 'targeted', label: 'Targeted (yield reached)', reason: '' },
+    stall: { stalled: false, weight_gain: 30 },
+    channeling: { channeling: false, pressure_drop: 0, flow_rise: 0 },
+    curve_adherence: null }],
+  phases: [], weight: { actual: 36, target: 36, deviation_pct: 0 }, total_time_s: 28,
+}
+
+describe('buildAnalyzeLlmPrompt', () => {
+  it('includes knowledge, fact sheet, few-shot', () => {
+    const p = buildAnalyzeLlmPrompt({
+      profileName: 'Test', temperature: 93, targetWeight: 36, profileDescription: 'desc',
+      profileVars: [], cleanStages: [], facts, tasteContext: '',
+    })
+    expect(p).toContain('EXIT TRIGGER CLASSIFICATION')
+    expect(p).toContain('Deterministic Shot Facts')
+    expect(p).toContain('Worked Example')
+  })
+  it('includes taste section when compass taste provided', () => {
+    const p = buildAnalyzeLlmPrompt({
+      profileName: 'Test', temperature: 93, targetWeight: 36, profileDescription: 'desc',
+      profileVars: [], cleanStages: [], facts,
+      tasteContext: '## Taste Goal\nUser wants less sour.',
+    })
+    expect(p).toContain('Taste Goal')
+  })
+})

--- a/apps/web/src/services/interceptor/analyzeLlmPrompt.test.ts
+++ b/apps/web/src/services/interceptor/analyzeLlmPrompt.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { buildAnalyzeLlmPrompt } from './analyzeLlmPrompt'
+import { computeRichLocalAnalysis } from './DirectModeInterceptor'
+import { buildShotFacts } from '../../lib/shotFacts'
 import type { ShotFacts } from '../../lib/shotFacts'
 
 const facts: ShotFacts = {
@@ -28,5 +30,48 @@ describe('buildAnalyzeLlmPrompt', () => {
       tasteContext: '## Taste Goal\nUser wants less sour.',
     })
     expect(p).toContain('Taste Goal')
+  })
+
+  it('includes expert profiling knowledge AND analysis framework (parity with server)', () => {
+    const p = buildAnalyzeLlmPrompt({
+      profileName: 'Test', temperature: 93, targetWeight: 36, profileDescription: 'desc',
+      profileVars: [], cleanStages: [], facts, tasteContext: '',
+    })
+    expect(p).toContain('ESPRESSO PROFILING GUIDE')
+    expect(p).toContain('EXIT TRIGGER CLASSIFICATION')
+  })
+
+  it('populates the fact sheet from a rich local analysis (guards the empty-facts bug)', () => {
+    // Realistic entry: a pressure-controlled stage with a weight exit trigger that fires.
+    const entry = {
+      id: 's1', time: Date.now(), name: 'Test Shot',
+      profile: {
+        name: 'Test Profile', final_weight: 36, temperature: 93,
+        stages: [
+          {
+            name: 'Extraction', type: 'pressure', key: 'extraction',
+            dynamics: { points: [[0, 9]], over: 'time' },
+            exit_triggers: [{ type: 'weight', value: 36, comparison: '>=' }],
+            limits: [],
+          },
+        ],
+        variables: [],
+      },
+      data: [
+        { status: 'Extraction', time: 0, profile_time: 0, shot: { pressure: 8.5, flow: 2.0, weight: 0 } },
+        { status: 'Extraction', time: 5000, profile_time: 5000, shot: { pressure: 9.0, flow: 2.1, weight: 12 } },
+        { status: 'Extraction', time: 15000, profile_time: 15000, shot: { pressure: 9.0, flow: 2.0, weight: 30 } },
+        { status: 'Extraction', time: 28000, profile_time: 28000, shot: { pressure: 9.0, flow: 1.8, weight: 36 } },
+      ],
+    }
+    const richAnalysis = computeRichLocalAnalysis(entry, 'Test Profile')
+    const populatedFacts = buildShotFacts(richAnalysis as Parameters<typeof buildShotFacts>[0])
+    const p = buildAnalyzeLlmPrompt({
+      profileName: 'Test Profile', temperature: 93, targetWeight: 36, profileDescription: 'desc',
+      profileVars: [], cleanStages: [], facts: populatedFacts, tasteContext: '',
+    })
+    // Fact sheet must reference the real stage and its targeted exit — not just an empty header.
+    expect(p).toContain('Extraction')
+    expect(p).toContain('Targeted')
   })
 })

--- a/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
+++ b/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
@@ -1,4 +1,5 @@
 import { ANALYSIS_KNOWLEDGE, FEW_SHOT_ANALYSIS_EXAMPLE, buildFactSheet } from '../ai/analysisKnowledge'
+import { PROFILING_KNOWLEDGE } from '../ai/profilePromptFull'
 import type { ShotFacts } from '../../lib/shotFacts'
 
 export interface AnalyzeLlmPromptInput {
@@ -19,6 +20,9 @@ export function buildAnalyzeLlmPrompt(input: AnalyzeLlmPromptInput): string {
     profileVars, cleanStages, facts, tasteContext, graphSamples = [],
   } = input
   return `You are an expert espresso barista and profiling specialist analyzing a shot from a Meticulous Espresso Machine.
+
+## Expert Knowledge
+${PROFILING_KNOWLEDGE}
 
 ## Analysis Framework
 ${ANALYSIS_KNOWLEDGE}

--- a/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
+++ b/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
@@ -11,13 +11,12 @@ export interface AnalyzeLlmPromptInput {
   cleanStages: unknown[]
   facts: ShotFacts
   tasteContext: string
-  graphSamples?: unknown[]
 }
 
 export function buildAnalyzeLlmPrompt(input: AnalyzeLlmPromptInput): string {
   const {
     profileName, temperature, targetWeight, profileDescription,
-    profileVars, cleanStages, facts, tasteContext, graphSamples = [],
+    profileVars, cleanStages, facts, tasteContext,
   } = input
   return `You are an expert espresso barista and profiling specialist analyzing a shot from a Meticulous Espresso Machine.
 
@@ -50,9 +49,6 @@ after the machine's piston retraction completes, so do NOT penalize weight devia
 exceeds ±5%.
 
 ${buildFactSheet(facts)}
-
-### Graph Sample Points
-${JSON.stringify(graphSamples, null, 2)}
 ${tasteContext ? `\n${tasteContext}\n` : ''}
 ${FEW_SHOT_ANALYSIS_EXAMPLE}
 

--- a/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
+++ b/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
@@ -41,20 +41,14 @@ ${JSON.stringify(profileVars, null, 2)}
 ### Profile Stages
 ${JSON.stringify(cleanStages, null, 2)}
 
-## Full Local Analysis
-This is the complete algorithmic analysis of the shot. Use this data to inform your expert analysis.
+## Shot Facts (digested — authoritative; trust over raw telemetry)
+Each stage lists its exit classification. A Targeted exit means the stage reached its intended
+outcome (e.g. its weight target); a Failsafe exit means a backstop fired before the real target.
+A Targeted exit — including a short stage that hit its weight target — is NORMAL and CORRECT
+behavior; never describe it as "early termination". The final weight reflects the settled weight
+after the machine's piston retraction completes, so do NOT penalize weight deviation unless it
+exceeds ±5%.
 
-IMPORTANT: Each stage includes 'cumulative_weight_at_end' which shows the total weight when that stage ended.
-If a stage ended early but the cumulative weight was near the target weight, the shot likely terminated
-correctly due to reaching the final weight target - this is NORMAL and EXPECTED behavior.
-A stage that appears "short" may simply mean the target yield was reached, which is the correct outcome.
-
-IMPORTANT: The 'final_weight_g' in shot_summary is the actual settled weight AFTER the machine's piston retraction completes.
-The Meticulous machine issues a stop signal BEFORE the target weight is reached, accounting for residual flow that will drip
-into the cup during piston retraction. This means the final weight accurately reflects the total liquid in the cup.
-Do NOT penalize the shot for weight deviation unless 'weight_deviation_pct' exceeds ±5%.
-
-## Shot Facts (digested)
 ${buildFactSheet(facts)}
 
 ### Graph Sample Points

--- a/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
+++ b/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
@@ -1,0 +1,146 @@
+import { ANALYSIS_KNOWLEDGE, FEW_SHOT_ANALYSIS_EXAMPLE, buildFactSheet } from '../ai/analysisKnowledge'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+export interface AnalyzeLlmPromptInput {
+  profileName: string
+  temperature: number | string | null
+  targetWeight: number | string | null
+  profileDescription: string
+  profileVars: unknown[]
+  cleanStages: unknown[]
+  facts: ShotFacts
+  tasteContext: string
+  graphSamples?: unknown[]
+}
+
+export function buildAnalyzeLlmPrompt(input: AnalyzeLlmPromptInput): string {
+  const {
+    profileName, temperature, targetWeight, profileDescription,
+    profileVars, cleanStages, facts, tasteContext, graphSamples = [],
+  } = input
+  return `You are an expert espresso barista and profiling specialist analyzing a shot from a Meticulous Espresso Machine.
+
+## Analysis Framework
+${ANALYSIS_KNOWLEDGE}
+
+## Profile Being Used
+Name: ${profileName}
+Temperature: ${temperature ?? 'Not set'}°C
+Target Weight: ${targetWeight ?? 'Not set'}g
+
+### Profile Description
+${profileDescription || 'No description provided - analyze the profile structure to understand intent.'}
+
+### Profile Variables
+${JSON.stringify(profileVars, null, 2)}
+
+### Profile Stages
+${JSON.stringify(cleanStages, null, 2)}
+
+## Full Local Analysis
+This is the complete algorithmic analysis of the shot. Use this data to inform your expert analysis.
+
+IMPORTANT: Each stage includes 'cumulative_weight_at_end' which shows the total weight when that stage ended.
+If a stage ended early but the cumulative weight was near the target weight, the shot likely terminated
+correctly due to reaching the final weight target - this is NORMAL and EXPECTED behavior.
+A stage that appears "short" may simply mean the target yield was reached, which is the correct outcome.
+
+IMPORTANT: The 'final_weight_g' in shot_summary is the actual settled weight AFTER the machine's piston retraction completes.
+The Meticulous machine issues a stop signal BEFORE the target weight is reached, accounting for residual flow that will drip
+into the cup during piston retraction. This means the final weight accurately reflects the total liquid in the cup.
+Do NOT penalize the shot for weight deviation unless 'weight_deviation_pct' exceeds ±5%.
+
+## Shot Facts (digested)
+${buildFactSheet(facts)}
+
+### Graph Sample Points
+${JSON.stringify(graphSamples, null, 2)}
+${tasteContext ? `\n${tasteContext}\n` : ''}
+${FEW_SHOT_ANALYSIS_EXAMPLE}
+
+---
+
+Based on this data, provide a detailed expert analysis.
+
+CRITICAL FORMATTING RULES:
+1. You MUST use EXACTLY these 5 section headers with the exact format shown (## followed by number, period, space, then title)
+2. Each section MUST have the subsection headers shown (bold text with colon, like **What Happened:**)
+3. ALL content under subsections MUST be bullet points starting with "- "
+4. Keep bullet points concise (1-2 sentences max per bullet)
+5. Do NOT add extra sections or subsections beyond what's specified
+
+## 1. Shot Performance
+
+**What Happened:**
+- [Stage-by-stage description of the extraction]
+- [Notable events: pressure spikes, flow restrictions, early/late stage exits]
+- [Final weight accuracy relative to target]
+
+**Assessment:** [Choose exactly one: Good / Acceptable / Needs Improvement / Problematic]
+
+## 2. Root Cause Analysis
+
+**Primary Factors:**
+- [Most likely cause with brief explanation]
+- [Second most likely cause if applicable]
+
+**Secondary Considerations:**
+- [Other contributing factors]
+- [Environmental or equipment factors if relevant]
+
+## 3. Setup Recommendations
+
+**Priority Changes:**
+- [Most important change - be specific with numbers when possible]
+- [Second priority change]
+
+**Additional Suggestions:**
+- [Other tweaks to consider]
+
+## 4. Profile Recommendations
+
+**Recommended Adjustments:**
+- [Specific profile changes: timing, triggers, targets]
+- [Variable value changes if applicable]
+
+**Reasoning:**
+- [Why these changes would improve the shot]
+
+## 5. Profile Design Observations
+
+**Strengths:**
+- [Well-designed aspects of this profile]
+
+**Potential Improvements:**
+- [Exit trigger or safety limit suggestions]
+- [Robustness improvements]
+
+Focus on actionable insights. Be specific with numbers where possible (e.g., "grind 1-2 steps finer" not just "grind finer").
+
+## Structured Recommendations (MANDATORY)
+
+After your analysis sections, you MUST output a structured JSON block with specific, actionable profile variable recommendations.
+Use EXACTLY this format — the markers are parsed programmatically:
+
+RECOMMENDATIONS_JSON:
+[
+  {
+    "variable": "<variable key from the profile, e.g. 'pressure', 'temperature'>",
+    "current_value": <current numeric value>,
+    "recommended_value": <suggested numeric value>,
+    "stage": "<stage name this applies to, or 'global' for top-level settings>",
+    "confidence": "<high|medium|low>",
+    "reason": "<one-sentence explanation>"
+  }
+]
+END_RECOMMENDATIONS_JSON
+
+Rules for recommendations:
+- Only include recommendations where you have a SPECIFIC numeric change to suggest
+- Use actual variable keys from the Profile Variables section above
+- For top-level settings (temperature, final_weight), use stage="global"
+- For stage-specific changes, use the stage name from Profile Stages
+- confidence: "high" = strong evidence from data, "medium" = likely beneficial, "low" = worth trying
+- If no recommendations apply, output an empty array: RECOMMENDATIONS_JSON:\n[]\nEND_RECOMMENDATIONS_JSON
+`
+}

--- a/docs/superpowers/plans/2026-06-30-ai-analysis-overhaul.md
+++ b/docs/superpowers/plans/2026-06-30-ai-analysis-overhaul.md
@@ -1,0 +1,2976 @@
+# AI Shot Analysis Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make AI shot analysis consistent across model sizes by adding a deterministic `ShotFacts` layer (incl. #423 Targeted/Failsafe trigger classification), feeding the AI digested facts + an analysis knowledge base + few-shot example, validating output against the facts, and integrating the Espresso Compass as an optional pre-analysis step — all mirrored across the Python (server) and TypeScript (native) runtimes.
+
+**Architecture:** A pure deterministic function (`build_shot_facts` / `buildShotFacts`) turns telemetry + profile + existing local analysis into a typed `ShotFacts` object. That object feeds (a) the enriched static analysis view, (b) a prose fact-sheet for the LLM prompt, and (c) a semantic validator that rejects/repairs AI claims contradicting the facts. The Espresso Compass becomes an optional pre-analysis step whose taste feeds both the AI and deterministic adjustment rules.
+
+**Tech Stack:** Python 3.13 / FastAPI / pytest (server); React + TypeScript / Vite / Vitest / Bun (native); i18n via react-i18next across 6 locales.
+
+**Spec:** `docs/superpowers/specs/2026-06-30-ai-analysis-overhaul-design.md`
+
+---
+
+## Dual-Runtime Rule (read first)
+
+Every behavior is implemented **twice** and must stay numerically/structurally identical:
+
+- **Server:** `apps/server/` (Python). Tests in `apps/server/test_*.py`, run with
+  `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest <file> -q`.
+- **Native:** `apps/web/` (TypeScript). Tests run with
+  `cd apps/web && bun run test:run -- --reporter=dot <paths>`
+  (the default reporter hangs; always pass `--reporter=dot` and explicit file paths).
+
+Mismatched behavior between runtimes is a **release-blocking** bug. Each phase below pairs the
+server task with its native parity task. Keep threshold constants identical across runtimes.
+
+**Baselines (do not regress):** server full suite currently green; web `tsc` has exactly 2
+pre-existing errors (`useGenerationProgress.ts:94`, `test/setup.ts:57`) — add none; lint 0
+errors. i18n: all locale files currently have equal key counts — a parity test enforces this.
+
+**Commit convention:** Conventional Commits + trailer
+`Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+NEVER stage `apps/web/ios/App/App.xcodeproj/project.pbxproj`.
+
+---
+
+## File Structure
+
+### New files
+- `apps/server/services/shot_facts.py` — pure `build_shot_facts()` + `classify_trigger()` +
+  detectors (D1–D5). Typed dataclasses. No I/O, no LLM.
+- `apps/server/analysis_knowledge.py` — `ANALYSIS_KNOWLEDGE` constant (K1) + `build_fact_sheet()` (K2).
+- `apps/server/services/compass_rules.py` — `compass_adjustments()` (D6).
+- `apps/server/services/analysis_validator.py` — `validate_analysis()` (K4/L1–L4) + shared schema.
+- `apps/web/src/lib/shotFacts.ts` — TS parity of `shot_facts.py` (D1–D5) + types.
+- `apps/web/src/services/ai/analysisKnowledge.ts` — `ANALYSIS_KNOWLEDGE` + `buildFactSheet()`.
+- `apps/web/src/lib/compassRules.ts` — `compassAdjustments()` (D6).
+- `apps/web/src/lib/analysisSchema.ts` — shared section-schema definition (L2), consumed by
+  prompt builder + linter.
+- Test files alongside each (`shot_facts` tests live in `apps/server/test_main.py` additions
+  for server; `apps/web/src/lib/shotFacts.test.ts` etc. for native).
+
+### Modified files
+- `apps/server/services/analysis_service.py` — call `build_shot_facts`, add facts to
+  `local_analysis`; `_prepare_shot_summary_for_llm` gains fact-sheet output.
+- `apps/server/api/routes/shots.py` — analyze-llm route: inject fact sheet + `ANALYSIS_KNOWLEDGE`,
+  run `validate_analysis`, accept taste already supported (`taste_x/taste_y/descriptors`).
+- `apps/server/prompt_builder.py` — reuse existing `build_taste_context` (no change unless noted).
+- `apps/web/src/services/interceptor/DirectModeInterceptor.ts` — inject `ANALYSIS_KNOWLEDGE`,
+  fact sheet, `buildTasteContext`, and run validator (currently returns raw text).
+- `apps/web/src/lib/analysisLint.ts` — extend to schema/bounds/anti-hallucination (L1/L4).
+- `apps/web/src/components/ShotHistoryView/ShotDetail.tsx` — render Targeted/Failsafe badges,
+  stall/channeling flags, phase breakdown, curve-adherence (enrich static view).
+- `apps/web/public/locales/{en,sv,de,es,fr,it}/translation.json` — new keys.
+
+---
+
+## Phase 1 — Deterministic Fact Layer (#423) + Static View
+
+### Task 1: Trigger classification — server (D1)
+
+**Files:**
+- Create: `apps/server/services/shot_facts.py`
+- Test: `apps/server/test_main.py` (append a `TestShotFactsClassify` class)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/server/test_main.py`:
+
+```python
+class TestShotFactsClassify:
+    """#423 Targeted vs Failsafe trigger classification."""
+
+    def test_weight_is_always_targeted(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("pressure", "weight", total_triggers=2)
+        assert r["kind"] == "targeted"
+        assert "yield" in r["label"].lower()
+
+    def test_time_only_trigger_is_planned_duration(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("flow", "time", total_triggers=1)
+        assert r["kind"] == "targeted"
+        assert "planned" in r["label"].lower()
+
+    def test_time_with_other_triggers_is_failsafe_timeout(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("flow", "time", total_triggers=2)
+        assert r["kind"] == "failsafe"
+        assert "timeout" in r["label"].lower()
+
+    def test_flow_control_pressure_trigger_is_puck_resistance(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("flow", "pressure", total_triggers=2)
+        assert r["kind"] == "targeted"
+        assert "resistance" in r["label"].lower()
+
+    def test_pressure_control_flow_only_trigger_is_planned_transition(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("pressure", "flow", total_triggers=1)
+        assert r["kind"] == "targeted"
+
+    def test_pressure_control_flow_with_others_is_failsafe_channeling(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("pressure", "flow", total_triggers=2)
+        assert r["kind"] == "failsafe"
+        assert "channel" in r["label"].lower() or "chok" in r["label"].lower()
+
+    def test_pressure_control_pressure_trigger_is_threshold(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("pressure", "pressure", total_triggers=1)
+        assert r["kind"] == "targeted"
+
+    def test_unknown_combo_returns_unknown(self):
+        from services.shot_facts import classify_trigger
+        r = classify_trigger("power", "weird", total_triggers=1)
+        assert r["kind"] == "unknown"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestShotFactsClassify -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'services.shot_facts'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/server/services/shot_facts.py`:
+
+```python
+"""Deterministic shot-fact derivation (#423 + diagnostic signals).
+
+Pure functions: telemetry + profile + local analysis -> typed facts. No I/O, no LLM.
+Mirrors apps/web/src/lib/shotFacts.ts — keep thresholds identical across runtimes.
+"""
+
+from __future__ import annotations
+
+
+def classify_trigger(
+    stage_control_mode: str, trigger_type: str, total_triggers: int
+) -> dict:
+    """Classify a stage's exit trigger as Targeted vs Failsafe (#423).
+
+    Args:
+        stage_control_mode: the variable the stage controls ('pressure' | 'flow' | other).
+        trigger_type: the exit trigger that fired ('weight' | 'time' | 'pressure' | 'flow').
+        total_triggers: number of exit triggers defined on the stage.
+
+    Returns:
+        {'kind': 'targeted'|'failsafe'|'unknown', 'label': str, 'reason': str}
+    """
+    if trigger_type == "weight":
+        return {
+            "kind": "targeted",
+            "label": "Targeted (yield reached)",
+            "reason": "Weight is the ultimate goal of the shot.",
+        }
+    if trigger_type == "time":
+        if total_triggers == 1:
+            return {
+                "kind": "targeted",
+                "label": "Targeted (planned duration)",
+                "reason": "Time is the only trigger, so this is an intentional timed stage.",
+            }
+        return {
+            "kind": "failsafe",
+            "label": "Failsafe (timeout limit)",
+            "reason": "Stage hit its time backstop before another target was reached.",
+        }
+    if stage_control_mode == "flow" and trigger_type == "pressure":
+        return {
+            "kind": "targeted",
+            "label": "Targeted (puck resistance achieved)",
+            "reason": "Flow-controlled stage reached its intended pressure.",
+        }
+    if stage_control_mode == "pressure" and trigger_type == "flow":
+        if total_triggers == 1:
+            return {
+                "kind": "targeted",
+                "label": "Targeted (planned flow transition)",
+                "reason": "Flow is the only trigger, so the transition is intentional.",
+            }
+        return {
+            "kind": "failsafe",
+            "label": "Failsafe (caught channeling or choking)",
+            "reason": "Pressure-controlled stage exited on a flow backstop.",
+        }
+    if stage_control_mode == "pressure" and trigger_type == "pressure":
+        return {
+            "kind": "targeted",
+            "label": "Targeted (pressure threshold reached)",
+            "reason": "Pressure-controlled stage reached its target pressure.",
+        }
+    return {
+        "kind": "unknown",
+        "label": "Unknown",
+        "reason": "Trigger/control-mode combination is not classified.",
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestShotFactsClassify -q`
+Expected: PASS (8 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/services/shot_facts.py apps/server/test_main.py
+git commit -m "feat(analysis): add #423 Targeted/Failsafe trigger classification (server)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 2: Shot-fact detectors + builder — server (D2–D5)
+
+**Files:**
+- Modify: `apps/server/services/shot_facts.py`
+- Test: `apps/server/test_main.py` (append `TestShotFacts`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/server/test_main.py`:
+
+```python
+class TestShotFacts:
+    def _stage(self, **kw):
+        base = {
+            "stage_name": "Infusion",
+            "stage_type": "flow",
+            "exit_triggers": [],
+            "execution_data": {
+                "duration": 10.0, "weight_gain": 2.0, "end_weight": 8.0,
+                "start_pressure": 1.0, "end_pressure": 6.0, "avg_pressure": 4.0,
+                "max_pressure": 6.5, "min_pressure": 1.0,
+                "start_flow": 4.0, "end_flow": 0.5, "avg_flow": 2.0, "max_flow": 4.5,
+            },
+            "exit_trigger_result": {"triggered": {"type": "time"}},
+        }
+        base.update(kw)
+        return base
+
+    def test_stall_detected_on_time_failsafe_with_low_gain(self):
+        from services.shot_facts import detect_stall
+        stage = self._stage(
+            stage_type="pressure",
+            exit_triggers=[{"type": "flow"}, {"type": "time"}],
+            exit_trigger_result={"triggered": {"type": "time"}},
+            execution_data={**self._stage()["execution_data"], "weight_gain": 0.3},
+        )
+        assert detect_stall(stage)["stalled"] is True
+
+    def test_no_stall_when_weight_trigger(self):
+        from services.shot_facts import detect_stall
+        stage = self._stage(exit_trigger_result={"triggered": {"type": "weight"}})
+        assert detect_stall(stage)["stalled"] is False
+
+    def test_channeling_flag_on_pressure_drop_with_flow_rise(self):
+        from services.shot_facts import detect_channeling
+        ed = {**self._stage()["execution_data"],
+              "start_pressure": 8.0, "end_pressure": 3.0,
+              "start_flow": 1.0, "end_flow": 5.0}
+        assert detect_channeling(ed)["channeling"] is True
+
+    def test_no_channeling_on_stable_stage(self):
+        from services.shot_facts import detect_channeling
+        ed = {**self._stage()["execution_data"],
+              "start_pressure": 6.0, "end_pressure": 6.2,
+              "start_flow": 2.0, "end_flow": 2.1}
+        assert detect_channeling(ed)["channeling"] is False
+
+    def test_build_shot_facts_classifies_each_stage(self):
+        from services.shot_facts import build_shot_facts
+        local = {
+            "stage_analyses": [
+                self._stage(
+                    stage_type="pressure",
+                    exit_triggers=[{"type": "weight"}],
+                    exit_trigger_result={"triggered": {"type": "weight"}},
+                ),
+            ],
+            "weight_analysis": {"actual": 36.0, "target": 36.0, "deviation_percent": 0.0},
+            "overall_metrics": {"total_time": 30.0},
+        }
+        facts = build_shot_facts(local)
+        assert len(facts["stages"]) == 1
+        assert facts["stages"][0]["trigger_class"]["kind"] == "targeted"
+        assert "phases" in facts
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestShotFacts -q`
+Expected: FAIL — `ImportError: cannot import name 'detect_stall'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `apps/server/services/shot_facts.py`:
+
+```python
+# Threshold constants — keep identical to apps/web/src/lib/shotFacts.ts
+STALL_MIN_WEIGHT_GAIN_G = 0.5  # below this on a time-failsafe = stalled
+CHANNELING_PRESSURE_DROP_BAR = 1.5  # pressure fall within a stage
+CHANNELING_FLOW_RISE_MLS = 1.5  # simultaneous flow rise
+
+
+def _stage_control_mode(stage: dict) -> str:
+    """Best-effort: which variable the stage controls."""
+    t = (stage.get("stage_type") or stage.get("type") or "").lower()
+    if "flow" in t:
+        return "flow"
+    if "pressure" in t:
+        return "pressure"
+    return "unknown"
+
+
+def detect_stall(stage: dict) -> dict:
+    """A stage stalled if it exited on a time failsafe with negligible weight gain."""
+    result = stage.get("exit_trigger_result") or {}
+    triggered = result.get("triggered") or {}
+    trig_type = triggered.get("type", "")
+    total = len(stage.get("exit_triggers") or [])
+    ed = stage.get("execution_data") or {}
+    gain = float(ed.get("weight_gain", 0) or 0)
+    klass = classify_trigger(_stage_control_mode(stage), trig_type, total)
+    stalled = klass["kind"] == "failsafe" and trig_type == "time" and gain < STALL_MIN_WEIGHT_GAIN_G
+    return {"stalled": stalled, "weight_gain": round(gain, 2)}
+
+
+def detect_channeling(execution_data: dict) -> dict:
+    """Flag likely channeling: pressure falls while flow rises within the stage."""
+    ed = execution_data or {}
+    p_drop = float(ed.get("start_pressure", 0) or 0) - float(ed.get("end_pressure", 0) or 0)
+    f_rise = float(ed.get("end_flow", 0) or 0) - float(ed.get("start_flow", 0) or 0)
+    channeling = p_drop >= CHANNELING_PRESSURE_DROP_BAR and f_rise >= CHANNELING_FLOW_RISE_MLS
+    return {"channeling": channeling, "pressure_drop": round(p_drop, 2), "flow_rise": round(f_rise, 2)}
+
+
+def _build_phases(local_analysis: dict) -> list[dict]:
+    """Group stages into pre-infusion / ramp / peak / decline by avg pressure shape."""
+    stages = [s for s in local_analysis.get("stage_analyses", []) if s.get("execution_data")]
+    phases: list[dict] = []
+    for s in stages:
+        ed = s["execution_data"]
+        avg_p = float(ed.get("avg_pressure", 0) or 0)
+        if avg_p < 3.0:
+            phase = "pre-infusion"
+        elif float(ed.get("end_pressure", 0) or 0) > float(ed.get("start_pressure", 0) or 0):
+            phase = "ramp"
+        elif float(ed.get("end_pressure", 0) or 0) < float(ed.get("start_pressure", 0) or 0):
+            phase = "decline"
+        else:
+            phase = "peak"
+        phases.append({
+            "stage_name": s.get("stage_name"),
+            "phase": phase,
+            "avg_pressure": ed.get("avg_pressure"),
+            "avg_flow": ed.get("avg_flow"),
+            "weight_gain": ed.get("weight_gain"),
+        })
+    return phases
+
+
+def _curve_adherence(stage: dict) -> dict | None:
+    """Compare measured avg vs the stage's first target dynamics point, if numeric."""
+    points = ((stage.get("profile_target") or {}) if isinstance(stage.get("profile_target"), dict) else {})
+    target = points.get("target_value")
+    ed = stage.get("execution_data") or {}
+    if target is None:
+        return None
+    mode = _stage_control_mode(stage)
+    measured = ed.get("avg_pressure") if mode == "pressure" else ed.get("avg_flow")
+    if measured is None:
+        return None
+    return {"target": target, "measured": measured, "delta": round(float(measured) - float(target), 2)}
+
+
+def build_shot_facts(local_analysis: dict) -> dict:
+    """Assemble the deterministic ShotFacts object consumed by the static view, the
+    LLM fact sheet, and the validator. Mirrors buildShotFacts() in shotFacts.ts."""
+    stages_out: list[dict] = []
+    for s in local_analysis.get("stage_analyses", []):
+        ed = s.get("execution_data")
+        if not ed:
+            stages_out.append({"stage_name": s.get("stage_name"), "reached": False})
+            continue
+        triggered = (s.get("exit_trigger_result") or {}).get("triggered") or {}
+        trig_type = triggered.get("type", "")
+        total = len(s.get("exit_triggers") or [])
+        stages_out.append({
+            "stage_name": s.get("stage_name"),
+            "reached": True,
+            "control_mode": _stage_control_mode(s),
+            "trigger_type": trig_type,
+            "trigger_class": classify_trigger(_stage_control_mode(s), trig_type, total),
+            "stall": detect_stall(s),
+            "channeling": detect_channeling(ed),
+            "curve_adherence": _curve_adherence(s),
+        })
+    wa = local_analysis.get("weight_analysis", {})
+    return {
+        "stages": stages_out,
+        "phases": _build_phases(local_analysis),
+        "weight": {
+            "actual": wa.get("actual"),
+            "target": wa.get("target"),
+            "deviation_pct": wa.get("deviation_percent"),
+        },
+        "total_time_s": local_analysis.get("overall_metrics", {}).get("total_time"),
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestShotFacts -q`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/services/shot_facts.py apps/server/test_main.py
+git commit -m "feat(analysis): add stall/channeling/phase/curve detectors + build_shot_facts (server)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 3: Wire ShotFacts into server local analysis output
+
+**Files:**
+- Modify: `apps/server/services/analysis_service.py` (`_perform_local_shot_analysis` return)
+- Test: `apps/server/test_main.py` (append to existing local-analysis tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/server/test_main.py`:
+
+```python
+class TestLocalAnalysisIncludesFacts:
+    def test_local_analysis_attaches_shot_facts(self):
+        from services.analysis_service import _perform_local_shot_analysis
+        # Minimal shot + profile that exercises at least one executed stage.
+        from test_fixtures import SAMPLE_SHOT_DATA, SAMPLE_PROFILE_DATA  # existing fixtures
+        result = _perform_local_shot_analysis(SAMPLE_SHOT_DATA, SAMPLE_PROFILE_DATA)
+        assert "shot_facts" in result
+        assert "stages" in result["shot_facts"]
+```
+
+> If `test_fixtures` with those names does not exist, reuse whatever sample shot/profile the
+> existing `_perform_local_shot_analysis` tests already use in `test_main.py` (search for
+> `_perform_local_shot_analysis(`), and assert the same two keys.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestLocalAnalysisIncludesFacts -q`
+Expected: FAIL — `KeyError: 'shot_facts'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/server/services/analysis_service.py`, add the import near the top with the other
+service imports:
+
+```python
+from services.shot_facts import build_shot_facts
+```
+
+Find the `return` dict at the end of `_perform_local_shot_analysis` (the dict containing
+`stage_analyses`, `weight_analysis`, `overall_metrics`, etc.) and add one key just before it
+returns. Build the facts from the dict you are about to return:
+
+```python
+    analysis_result = {
+        # ... existing keys (overall_metrics, weight_analysis, stage_analyses, ...) ...
+    }
+    analysis_result["shot_facts"] = build_shot_facts(analysis_result)
+    return analysis_result
+```
+
+> If the function currently does `return { ... }` inline, refactor to assign to
+> `analysis_result` first, then attach `shot_facts`, then `return analysis_result`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestLocalAnalysisIncludesFacts -q`
+Expected: PASS
+
+- [ ] **Step 5: Run the full analysis test group to ensure no regression**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py -k "analysis or Analysis or shot or Shot" -q`
+Expected: PASS (no failures)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/server/services/analysis_service.py apps/server/test_main.py
+git commit -m "feat(analysis): attach shot_facts to local analysis output (server)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 4: ShotFacts parity — native (D1–D5)
+
+The native local analysis (`DirectModeInterceptor.ts` ~2895–2943) emits the **same snake_case
+field names** as the server (`stage_name`, `stage_type`, `execution_data.{start,end,avg}_pressure`,
+`exit_trigger_result.triggered.type`, `exit_triggers[]`, `weight_analysis.{actual,target,deviation_percent}`).
+Only difference: total time is `analysis.shot_summary.total_time` (not `overall_metrics`).
+So `shotFacts.ts` is a near-direct port of `shot_facts.py`.
+
+**Files:**
+- Create: `apps/web/src/lib/shotFacts.ts`
+- Test: `apps/web/src/lib/shotFacts.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/lib/shotFacts.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { classifyTrigger, detectStall, detectChanneling, buildShotFacts } from './shotFacts'
+
+describe('classifyTrigger (#423)', () => {
+  it('weight is always targeted', () => {
+    expect(classifyTrigger('pressure', 'weight', 2).kind).toBe('targeted')
+  })
+  it('time-only trigger is planned duration', () => {
+    expect(classifyTrigger('flow', 'time', 1).kind).toBe('targeted')
+  })
+  it('time with other triggers is failsafe timeout', () => {
+    const r = classifyTrigger('flow', 'time', 2)
+    expect(r.kind).toBe('failsafe')
+    expect(r.label.toLowerCase()).toContain('timeout')
+  })
+  it('flow control + pressure trigger is puck resistance', () => {
+    expect(classifyTrigger('flow', 'pressure', 2).kind).toBe('targeted')
+  })
+  it('pressure control + flow-only trigger is planned transition', () => {
+    expect(classifyTrigger('pressure', 'flow', 1).kind).toBe('targeted')
+  })
+  it('pressure control + flow with others is failsafe channeling', () => {
+    expect(classifyTrigger('pressure', 'flow', 2).kind).toBe('failsafe')
+  })
+  it('pressure control + pressure trigger is threshold', () => {
+    expect(classifyTrigger('pressure', 'pressure', 1).kind).toBe('targeted')
+  })
+  it('unknown combo returns unknown', () => {
+    expect(classifyTrigger('power', 'weird', 1).kind).toBe('unknown')
+  })
+})
+
+describe('detectStall / detectChanneling', () => {
+  const ed = {
+    duration: 10, weight_gain: 2, end_weight: 8,
+    start_pressure: 1, end_pressure: 6, avg_pressure: 4, max_pressure: 6.5, min_pressure: 1,
+    start_flow: 4, end_flow: 0.5, avg_flow: 2, max_flow: 4.5,
+  }
+  it('flags stall on time failsafe with low gain', () => {
+    const stage = {
+      stage_type: 'pressure',
+      exit_triggers: [{ type: 'flow' }, { type: 'time' }],
+      exit_trigger_result: { triggered: { type: 'time' } },
+      execution_data: { ...ed, weight_gain: 0.3 },
+    }
+    expect(detectStall(stage).stalled).toBe(true)
+  })
+  it('no stall when weight trigger', () => {
+    const stage = { stage_type: 'flow', exit_triggers: [{ type: 'weight' }], exit_trigger_result: { triggered: { type: 'weight' } }, execution_data: ed }
+    expect(detectStall(stage).stalled).toBe(false)
+  })
+  it('flags channeling on pressure drop with flow rise', () => {
+    expect(detectChanneling({ ...ed, start_pressure: 8, end_pressure: 3, start_flow: 1, end_flow: 5 }).channeling).toBe(true)
+  })
+  it('no channeling on stable stage', () => {
+    expect(detectChanneling({ ...ed, start_pressure: 6, end_pressure: 6.2, start_flow: 2, end_flow: 2.1 }).channeling).toBe(false)
+  })
+})
+
+describe('buildShotFacts', () => {
+  it('classifies each stage and reads total time from shot_summary', () => {
+    const analysis = {
+      shot_summary: { total_time: 30 },
+      weight_analysis: { actual: 36, target: 36, deviation_percent: 0 },
+      stage_analyses: [{
+        stage_name: 'Infusion', stage_type: 'pressure',
+        exit_triggers: [{ type: 'weight' }],
+        exit_trigger_result: { triggered: { type: 'weight' } },
+        execution_data: { duration: 10, weight_gain: 2, end_weight: 8, start_pressure: 6, end_pressure: 6, avg_pressure: 6, max_pressure: 6, min_pressure: 6, start_flow: 2, end_flow: 2, avg_flow: 2, max_flow: 2 },
+      }],
+    }
+    const facts = buildShotFacts(analysis)
+    expect(facts.stages).toHaveLength(1)
+    expect(facts.stages[0].trigger_class?.kind).toBe('targeted')
+    expect(facts.total_time_s).toBe(30)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/shotFacts.test.ts`
+Expected: FAIL — cannot find module `./shotFacts`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/web/src/lib/shotFacts.ts`:
+
+```typescript
+/**
+ * Deterministic shot-fact derivation (#423 + diagnostic signals).
+ * TS parity of apps/server/services/shot_facts.py — keep thresholds identical.
+ */
+
+// Threshold constants — keep identical to shot_facts.py
+export const STALL_MIN_WEIGHT_GAIN_G = 0.5
+export const CHANNELING_PRESSURE_DROP_BAR = 1.5
+export const CHANNELING_FLOW_RISE_MLS = 1.5
+
+export type TriggerKind = 'targeted' | 'failsafe' | 'unknown'
+export interface TriggerClass { kind: TriggerKind; label: string; reason: string }
+export interface StallResult { stalled: boolean; weight_gain: number }
+export interface ChannelingResult { channeling: boolean; pressure_drop: number; flow_rise: number }
+
+interface ExecutionData {
+  duration?: number; weight_gain?: number; end_weight?: number
+  start_pressure?: number; end_pressure?: number; avg_pressure?: number; max_pressure?: number; min_pressure?: number
+  start_flow?: number; end_flow?: number; avg_flow?: number; max_flow?: number
+}
+interface StageAnalysis {
+  stage_name?: string; stage_type?: string; type?: string
+  exit_triggers?: Array<{ type?: string }>
+  exit_trigger_result?: { triggered?: { type?: string } | null } | null
+  execution_data?: ExecutionData | null
+  profile_target?: { target_value?: number } | unknown
+}
+export interface ShotFactStage {
+  stage_name?: string
+  reached: boolean
+  control_mode?: string
+  trigger_type?: string
+  trigger_class?: TriggerClass
+  stall?: StallResult
+  channeling?: ChannelingResult
+  curve_adherence?: { target: number; measured: number; delta: number } | null
+}
+export interface ShotFacts {
+  stages: ShotFactStage[]
+  phases: Array<{ stage_name?: string; phase: string; avg_pressure?: number; avg_flow?: number; weight_gain?: number }>
+  weight: { actual?: number; target?: number; deviation_pct?: number }
+  total_time_s?: number
+}
+
+const n = (v: unknown): number => (typeof v === 'number' && !Number.isNaN(v) ? v : 0)
+const r2 = (v: number): number => Math.round(v * 100) / 100
+
+export function classifyTrigger(stageControlMode: string, triggerType: string, totalTriggers: number): TriggerClass {
+  if (triggerType === 'weight') {
+    return { kind: 'targeted', label: 'Targeted (yield reached)', reason: 'Weight is the ultimate goal of the shot.' }
+  }
+  if (triggerType === 'time') {
+    return totalTriggers === 1
+      ? { kind: 'targeted', label: 'Targeted (planned duration)', reason: 'Time is the only trigger, so this is an intentional timed stage.' }
+      : { kind: 'failsafe', label: 'Failsafe (timeout limit)', reason: 'Stage hit its time backstop before another target was reached.' }
+  }
+  if (stageControlMode === 'flow' && triggerType === 'pressure') {
+    return { kind: 'targeted', label: 'Targeted (puck resistance achieved)', reason: 'Flow-controlled stage reached its intended pressure.' }
+  }
+  if (stageControlMode === 'pressure' && triggerType === 'flow') {
+    return totalTriggers === 1
+      ? { kind: 'targeted', label: 'Targeted (planned flow transition)', reason: 'Flow is the only trigger, so the transition is intentional.' }
+      : { kind: 'failsafe', label: 'Failsafe (caught channeling or choking)', reason: 'Pressure-controlled stage exited on a flow backstop.' }
+  }
+  if (stageControlMode === 'pressure' && triggerType === 'pressure') {
+    return { kind: 'targeted', label: 'Targeted (pressure threshold reached)', reason: 'Pressure-controlled stage reached its target pressure.' }
+  }
+  return { kind: 'unknown', label: 'Unknown', reason: 'Trigger/control-mode combination is not classified.' }
+}
+
+function stageControlMode(stage: StageAnalysis): string {
+  const t = (stage.stage_type ?? stage.type ?? '').toLowerCase()
+  if (t.includes('flow')) return 'flow'
+  if (t.includes('pressure')) return 'pressure'
+  return 'unknown'
+}
+
+export function detectStall(stage: StageAnalysis): StallResult {
+  const trigType = stage.exit_trigger_result?.triggered?.type ?? ''
+  const total = (stage.exit_triggers ?? []).length
+  const gain = n(stage.execution_data?.weight_gain)
+  const klass = classifyTrigger(stageControlMode(stage), trigType, total)
+  const stalled = klass.kind === 'failsafe' && trigType === 'time' && gain < STALL_MIN_WEIGHT_GAIN_G
+  return { stalled, weight_gain: r2(gain) }
+}
+
+export function detectChanneling(ed: ExecutionData): ChannelingResult {
+  const pDrop = n(ed.start_pressure) - n(ed.end_pressure)
+  const fRise = n(ed.end_flow) - n(ed.start_flow)
+  return {
+    channeling: pDrop >= CHANNELING_PRESSURE_DROP_BAR && fRise >= CHANNELING_FLOW_RISE_MLS,
+    pressure_drop: r2(pDrop),
+    flow_rise: r2(fRise),
+  }
+}
+
+function buildPhases(stages: StageAnalysis[]): ShotFacts['phases'] {
+  return stages
+    .filter(s => s.execution_data)
+    .map(s => {
+      const ed = s.execution_data as ExecutionData
+      const avgP = n(ed.avg_pressure)
+      let phase: string
+      if (avgP < 3.0) phase = 'pre-infusion'
+      else if (n(ed.end_pressure) > n(ed.start_pressure)) phase = 'ramp'
+      else if (n(ed.end_pressure) < n(ed.start_pressure)) phase = 'decline'
+      else phase = 'peak'
+      return { stage_name: s.stage_name, phase, avg_pressure: ed.avg_pressure, avg_flow: ed.avg_flow, weight_gain: ed.weight_gain }
+    })
+}
+
+function curveAdherence(stage: StageAnalysis): ShotFactStage['curve_adherence'] {
+  const pt = stage.profile_target as { target_value?: number } | undefined
+  const target = pt?.target_value
+  if (target == null) return null
+  const mode = stageControlMode(stage)
+  const measured = mode === 'pressure' ? stage.execution_data?.avg_pressure : stage.execution_data?.avg_flow
+  if (measured == null) return null
+  return { target, measured, delta: r2(measured - target) }
+}
+
+export function buildShotFacts(analysis: {
+  stage_analyses?: StageAnalysis[]
+  weight_analysis?: { actual?: number; target?: number; deviation_percent?: number }
+  shot_summary?: { total_time?: number }
+  overall_metrics?: { total_time?: number }
+}): ShotFacts {
+  const stages = analysis.stage_analyses ?? []
+  const stagesOut: ShotFactStage[] = stages.map(s => {
+    if (!s.execution_data) return { stage_name: s.stage_name, reached: false }
+    const trigType = s.exit_trigger_result?.triggered?.type ?? ''
+    const total = (s.exit_triggers ?? []).length
+    return {
+      stage_name: s.stage_name,
+      reached: true,
+      control_mode: stageControlMode(s),
+      trigger_type: trigType,
+      trigger_class: classifyTrigger(stageControlMode(s), trigType, total),
+      stall: detectStall(s),
+      channeling: detectChanneling(s.execution_data),
+      curve_adherence: curveAdherence(s),
+    }
+  })
+  const wa = analysis.weight_analysis ?? {}
+  return {
+    stages: stagesOut,
+    phases: buildPhases(stages),
+    weight: { actual: wa.actual, target: wa.target, deviation_pct: wa.deviation_percent },
+    total_time_s: analysis.shot_summary?.total_time ?? analysis.overall_metrics?.total_time,
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/shotFacts.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Wire into the native local analysis response**
+
+In `DirectModeInterceptor.ts`, add the import at the top with the other lib imports:
+
+```typescript
+import { buildShotFacts } from '../../lib/shotFacts'
+```
+
+Find the `const analysis = { ... }` block (~2895) and attach facts right before `return jsonResponse(...)` at ~2944:
+
+```typescript
+          ;(analysis as Record<string, unknown>).shot_facts = buildShotFacts(analysis as Parameters<typeof buildShotFacts>[0])
+          return jsonResponse({ status: 'success', analysis })
+```
+
+- [ ] **Step 6: Run the interceptor local-analysis tests to confirm no regression**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/services/interceptor`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/lib/shotFacts.ts apps/web/src/lib/shotFacts.test.ts apps/web/src/services/interceptor/DirectModeInterceptor.ts
+git commit -m "feat(analysis): add ShotFacts parity + wire into native local analysis
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 5: Enrich the static analysis view with ShotFacts (Q3)
+
+Render Targeted/Failsafe badges, stall + channeling flags, and curve-adherence deltas in the
+existing local-analysis view. Implemented as a focused presentational subcomponent so it is
+unit-testable in isolation, then mounted in `ShotDetail.tsx`.
+
+**Files:**
+- Modify: `apps/web/src/components/ShotHistoryView/types.ts` (add `shot_facts?` to `LocalAnalysisResult`)
+- Create: `apps/web/src/components/ShotHistoryView/ShotFactsPanel.tsx`
+- Create: `apps/web/src/components/ShotHistoryView/ShotFactsPanel.test.tsx`
+- Modify: `apps/web/src/components/ShotHistoryView/ShotDetail.tsx` (mount the panel)
+- Modify: `apps/web/public/locales/{en,sv,de,es,fr,it}/translation.json`
+
+- [ ] **Step 1: Add the type**
+
+In `apps/web/src/components/ShotHistoryView/types.ts`, add the import and field:
+
+```typescript
+import type { ShotFacts } from '../../lib/shotFacts'
+```
+
+Then add one optional property to `LocalAnalysisResult` (after `profile_target_curves?`):
+
+```typescript
+  profile_target_curves?: ProfileTargetPoint[]
+  shot_facts?: ShotFacts
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web/src/components/ShotHistoryView/ShotFactsPanel.test.tsx`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ShotFactsPanel } from './ShotFactsPanel'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+// i18n is mocked globally in test/setup.ts to echo keys; assert on key fragments.
+const facts: ShotFacts = {
+  stages: [
+    { stage_name: 'Infusion', reached: true, control_mode: 'pressure', trigger_type: 'weight',
+      trigger_class: { kind: 'targeted', label: 'Targeted (yield reached)', reason: '' },
+      stall: { stalled: false, weight_gain: 30 },
+      channeling: { channeling: false, pressure_drop: 0.1, flow_rise: 0.1 },
+      curve_adherence: { target: 9, measured: 8.5, delta: -0.5 } },
+    { stage_name: 'Decline', reached: true, control_mode: 'pressure', trigger_type: 'time',
+      trigger_class: { kind: 'failsafe', label: 'Failsafe (timeout limit)', reason: '' },
+      stall: { stalled: true, weight_gain: 0.2 },
+      channeling: { channeling: true, pressure_drop: 3, flow_rise: 2 },
+      curve_adherence: null },
+  ],
+  phases: [],
+  weight: { actual: 36, target: 36, deviation_pct: 0 },
+  total_time_s: 30,
+}
+
+describe('ShotFactsPanel', () => {
+  it('renders a row per stage with its trigger label', () => {
+    render(<ShotFactsPanel facts={facts} />)
+    expect(screen.getByText('Infusion')).toBeInTheDocument()
+    expect(screen.getByText('Decline')).toBeInTheDocument()
+    expect(screen.getByText('Targeted (yield reached)')).toBeInTheDocument()
+    expect(screen.getByText('Failsafe (timeout limit)')).toBeInTheDocument()
+  })
+
+  it('shows stall and channeling flags when present', () => {
+    render(<ShotFactsPanel facts={facts} />)
+    expect(screen.getByText('analysis.facts.stalled')).toBeInTheDocument()
+    expect(screen.getByText('analysis.facts.channeling')).toBeInTheDocument()
+  })
+
+  it('renders nothing when facts has no reached stages', () => {
+    const { container } = render(<ShotFactsPanel facts={{ ...facts, stages: [] }} />)
+    expect(container.firstChild).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/components/ShotHistoryView/ShotFactsPanel.test.tsx`
+Expected: FAIL — cannot find module `./ShotFactsPanel`
+
+- [ ] **Step 4: Write the component**
+
+Create `apps/web/src/components/ShotHistoryView/ShotFactsPanel.tsx`:
+
+```typescript
+import { useTranslation } from 'react-i18next'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+interface Props {
+  facts: ShotFacts
+}
+
+export function ShotFactsPanel({ facts }: Props) {
+  const { t } = useTranslation()
+  const reached = facts.stages.filter(s => s.reached)
+  if (reached.length === 0) return null
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <h3 className="text-sm font-semibold text-foreground">{t('analysis.facts.title')}</h3>
+      <ul className="space-y-2">
+        {reached.map((s, i) => (
+          <li key={`${s.stage_name}-${i}`} className="flex flex-col gap-1 border-b border-border/50 pb-2 last:border-0 last:pb-0">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm font-medium text-foreground">{s.stage_name}</span>
+              {s.trigger_class && (
+                <span
+                  className={
+                    'text-xs px-2 py-0.5 rounded-full ' +
+                    (s.trigger_class.kind === 'targeted'
+                      ? 'bg-emerald-500/15 text-emerald-400'
+                      : s.trigger_class.kind === 'failsafe'
+                        ? 'bg-amber-500/15 text-amber-400'
+                        : 'bg-muted text-muted-foreground')
+                  }
+                >
+                  {s.trigger_class.label}
+                </span>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs">
+              {s.stall?.stalled && (
+                <span className="px-2 py-0.5 rounded bg-red-500/15 text-red-400">{t('analysis.facts.stalled')}</span>
+              )}
+              {s.channeling?.channeling && (
+                <span className="px-2 py-0.5 rounded bg-red-500/15 text-red-400">{t('analysis.facts.channeling')}</span>
+              )}
+              {s.curve_adherence && Math.abs(s.curve_adherence.delta) >= 0.5 && (
+                <span className="px-2 py-0.5 rounded bg-muted text-muted-foreground">
+                  {t('analysis.facts.curveDelta', { delta: s.curve_adherence.delta })}
+                </span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/components/ShotHistoryView/ShotFactsPanel.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Add i18n keys (all 6 locales)**
+
+Add an `analysis.facts` block. If an `analysis` object already exists in a locale file, nest
+`facts` inside it; otherwise add a top-level `analysis` object. Use these exact values:
+
+`en`:
+```json
+"analysis": {
+  "facts": {
+    "title": "Stage signals",
+    "stalled": "Stalled",
+    "channeling": "Possible channeling",
+    "curveDelta": "Curve Δ {{delta}}"
+  }
+}
+```
+`sv`:
+```json
+"analysis": { "facts": { "title": "Stegsignaler", "stalled": "Avstannade", "channeling": "Möjlig kanalbildning", "curveDelta": "Kurva Δ {{delta}}" } }
+```
+`de`:
+```json
+"analysis": { "facts": { "title": "Phasensignale", "stalled": "Stehengeblieben", "channeling": "Mögliches Channeling", "curveDelta": "Kurve Δ {{delta}}" } }
+```
+`es`:
+```json
+"analysis": { "facts": { "title": "Señales de fase", "stalled": "Estancado", "channeling": "Posible canalización", "curveDelta": "Curva Δ {{delta}}" } }
+```
+`fr`:
+```json
+"analysis": { "facts": { "title": "Signaux de phase", "stalled": "Bloqué", "channeling": "Chenalisation possible", "curveDelta": "Courbe Δ {{delta}}" } }
+```
+`it`:
+```json
+"analysis": { "facts": { "title": "Segnali di fase", "stalled": "Bloccato", "channeling": "Possibile canalizzazione", "curveDelta": "Curva Δ {{delta}}" } }
+```
+
+> If `analysis` already exists in a file, merge `facts` into it rather than adding a duplicate key.
+
+- [ ] **Step 7: Mount the panel in ShotDetail**
+
+In `apps/web/src/components/ShotHistoryView/ShotDetail.tsx`, add the import (near the other
+component imports):
+
+```typescript
+import { ShotFactsPanel } from './ShotFactsPanel'
+```
+
+Find where the local `analysisResult` is rendered (the section that shows stage analyses /
+weight analysis). Immediately above that section, render the panel when facts exist:
+
+```tsx
+{analysisResult?.shot_facts && <ShotFactsPanel facts={analysisResult.shot_facts} />}
+```
+
+> Place it inside the same conditional block guarded by `analysisResult` so it only appears
+> once local analysis has loaded. Search for `analysisResult.weight_analysis` or
+> `analysisResult.stage_analyses` to locate the render region.
+
+- [ ] **Step 8: Verify locale parity + types + lint**
+
+Run:
+```bash
+cd apps/web && bun run test:run -- --reporter=dot src/components/ShotHistoryView/ShotFactsPanel.test.tsx
+npx tsc --noEmit 2>&1 | grep -v "useGenerationProgress.ts:94\|test/setup.ts:57" | grep "error TS" || echo "tsc baseline OK"
+bunx eslint src/components/ShotHistoryView/ShotFactsPanel.tsx src/lib/shotFacts.ts
+```
+Expected: tests PASS, no new tsc errors, eslint clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/components/ShotHistoryView/types.ts apps/web/src/components/ShotHistoryView/ShotFactsPanel.tsx apps/web/src/components/ShotHistoryView/ShotFactsPanel.test.tsx apps/web/src/components/ShotHistoryView/ShotDetail.tsx apps/web/public/locales
+git commit -m "feat(analysis): enrich static analysis view with ShotFacts badges + i18n
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 6: Compass deterministic rules — both runtimes (D6)
+
+Pure functions mapping compass taste coordinates (X: -1 sour ↔ 1 bitter, Y: -1 weak/thin ↔
+1 strong/heavy) to concrete dial-in adjustment suggestions. Used deterministically (and later
+fed to the AI in Phase 3). Mirrors the domain knowledge already in
+`apps/server/prompt_builder.py:build_taste_context`.
+
+**Files:**
+- Create: `apps/server/services/compass_rules.py`
+- Create: `apps/web/src/lib/compassRules.ts`
+- Test: `apps/server/test_main.py` (`TestCompassRules`) + `apps/web/src/lib/compassRules.test.ts`
+
+- [ ] **Step 1: Write the failing tests (both runtimes)**
+
+Append to `apps/server/test_main.py`:
+
+```python
+class TestCompassRules:
+    def test_sour_and_weak_suggests_finer_and_hotter(self):
+        from services.compass_rules import compass_adjustments
+        adj = compass_adjustments(taste_x=-0.8, taste_y=-0.6)
+        kinds = {a["kind"] for a in adj}
+        assert "grind_finer" in kinds
+        assert any(a["kind"] in ("temp_up", "ratio_up", "dose_up") for a in adj)
+
+    def test_bitter_and_strong_suggests_coarser_and_cooler(self):
+        from services.compass_rules import compass_adjustments
+        adj = compass_adjustments(taste_x=0.8, taste_y=0.7)
+        kinds = {a["kind"] for a in adj}
+        assert "grind_coarser" in kinds
+
+    def test_centered_taste_returns_no_changes(self):
+        from services.compass_rules import compass_adjustments
+        assert compass_adjustments(taste_x=0.0, taste_y=0.0) == []
+```
+
+Create `apps/web/src/lib/compassRules.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { compassAdjustments } from './compassRules'
+
+describe('compassAdjustments (D6)', () => {
+  it('sour + weak suggests finer and hotter', () => {
+    const adj = compassAdjustments(-0.8, -0.6)
+    const kinds = adj.map(a => a.kind)
+    expect(kinds).toContain('grind_finer')
+    expect(kinds.some(k => ['temp_up', 'ratio_up', 'dose_up'].includes(k))).toBe(true)
+  })
+  it('bitter + strong suggests coarser', () => {
+    expect(compassAdjustments(0.8, 0.7).map(a => a.kind)).toContain('grind_coarser')
+  })
+  it('centered taste returns no changes', () => {
+    expect(compassAdjustments(0, 0)).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run both to verify they fail**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestCompassRules -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'services.compass_rules'`
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/compassRules.test.ts`
+Expected: FAIL — cannot find module `./compassRules`
+
+- [ ] **Step 3: Implement (server)**
+
+Create `apps/server/services/compass_rules.py`:
+
+```python
+"""Deterministic Espresso-Compass taste -> dial-in adjustment rules (D6).
+
+X axis: -1 sour ... +1 bitter.   Y axis: -1 weak/thin ... +1 strong/heavy.
+Mirrors apps/web/src/lib/compassRules.ts and the domain knowledge in
+prompt_builder.build_taste_context. Pure function — no I/O.
+"""
+
+from __future__ import annotations
+
+DEADBAND = 0.25  # within this radius of center, taste is considered balanced
+
+
+def compass_adjustments(taste_x: float, taste_y: float) -> list[dict]:
+    """Return ordered, concrete adjustment suggestions for the given taste vector."""
+    adjustments: list[dict] = []
+
+    # X axis — acidity/bitterness balance, primarily extraction yield.
+    if taste_x <= -DEADBAND:  # too sour -> under-extracted -> extract more
+        adjustments.append({"kind": "grind_finer", "axis": "x",
+                            "reason": "Sour/acidic indicates under-extraction; grind finer to raise yield."})
+        adjustments.append({"kind": "temp_up", "axis": "x",
+                            "reason": "A few degrees hotter increases extraction of sweet/bitter compounds."})
+    elif taste_x >= DEADBAND:  # too bitter -> over-extracted -> extract less
+        adjustments.append({"kind": "grind_coarser", "axis": "x",
+                            "reason": "Bitter/harsh indicates over-extraction; grind coarser to lower yield."})
+        adjustments.append({"kind": "temp_down", "axis": "x",
+                            "reason": "A few degrees cooler reduces harsh bitter extraction."})
+
+    # Y axis — strength/body, primarily ratio/dose.
+    if taste_y <= -DEADBAND:  # too weak/thin -> increase concentration
+        adjustments.append({"kind": "ratio_up", "axis": "y",
+                            "reason": "Weak/thin body; lower the brew ratio (less water per dose) for more concentration."})
+        adjustments.append({"kind": "dose_up", "axis": "y",
+                            "reason": "A larger dose increases strength and body."})
+    elif taste_y >= DEADBAND:  # too strong/heavy -> dilute
+        adjustments.append({"kind": "ratio_down", "axis": "y",
+                            "reason": "Strong/heavy; raise the brew ratio (more water per dose) to lighten."})
+
+    return adjustments
+```
+
+- [ ] **Step 4: Implement (native)**
+
+Create `apps/web/src/lib/compassRules.ts`:
+
+```typescript
+/**
+ * Deterministic Espresso-Compass taste -> dial-in adjustment rules (D6).
+ * X: -1 sour ... +1 bitter.   Y: -1 weak/thin ... +1 strong/heavy.
+ * TS parity of apps/server/services/compass_rules.py — keep DEADBAND identical.
+ */
+
+export const COMPASS_DEADBAND = 0.25
+
+export type CompassAdjustmentKind =
+  | 'grind_finer' | 'grind_coarser' | 'temp_up' | 'temp_down'
+  | 'ratio_up' | 'ratio_down' | 'dose_up'
+
+export interface CompassAdjustment {
+  kind: CompassAdjustmentKind
+  axis: 'x' | 'y'
+  reason: string
+}
+
+export function compassAdjustments(tasteX: number, tasteY: number): CompassAdjustment[] {
+  const adjustments: CompassAdjustment[] = []
+
+  if (tasteX <= -COMPASS_DEADBAND) {
+    adjustments.push({ kind: 'grind_finer', axis: 'x', reason: 'Sour/acidic indicates under-extraction; grind finer to raise yield.' })
+    adjustments.push({ kind: 'temp_up', axis: 'x', reason: 'A few degrees hotter increases extraction of sweet/bitter compounds.' })
+  } else if (tasteX >= COMPASS_DEADBAND) {
+    adjustments.push({ kind: 'grind_coarser', axis: 'x', reason: 'Bitter/harsh indicates over-extraction; grind coarser to lower yield.' })
+    adjustments.push({ kind: 'temp_down', axis: 'x', reason: 'A few degrees cooler reduces harsh bitter extraction.' })
+  }
+
+  if (tasteY <= -COMPASS_DEADBAND) {
+    adjustments.push({ kind: 'ratio_up', axis: 'y', reason: 'Weak/thin body; lower the brew ratio (less water per dose) for more concentration.' })
+    adjustments.push({ kind: 'dose_up', axis: 'y', reason: 'A larger dose increases strength and body.' })
+  } else if (tasteY >= COMPASS_DEADBAND) {
+    adjustments.push({ kind: 'ratio_down', axis: 'y', reason: 'Strong/heavy; raise the brew ratio (more water per dose) to lighten.' })
+  }
+
+  return adjustments
+}
+```
+
+- [ ] **Step 5: Run both to verify they pass**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestCompassRules -q` → PASS
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/compassRules.test.ts` → PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/server/services/compass_rules.py apps/web/src/lib/compassRules.ts apps/web/src/lib/compassRules.test.ts apps/server/test_main.py
+git commit -m "feat(analysis): add deterministic compass adjustment rules (both runtimes)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+**Phase 1 complete.** Deterministic ShotFacts (D1–D5) + compass rules (D6) exist and are wired
+into both local-analysis paths, with the static view enriched. No AI changes yet.
+
+## Phase 2 — Upgraded AI Layer (K1–K5)
+
+### Task 7: ANALYSIS_KNOWLEDGE + fact sheet — server (K1 + K2)
+
+**Files:**
+- Create: `apps/server/analysis_knowledge.py`
+- Test: `apps/server/test_main.py` (`TestAnalysisKnowledge`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/server/test_main.py`:
+
+```python
+class TestAnalysisKnowledge:
+    def test_knowledge_constant_covers_trigger_classes(self):
+        from analysis_knowledge import ANALYSIS_KNOWLEDGE
+        assert "Targeted" in ANALYSIS_KNOWLEDGE
+        assert "Failsafe" in ANALYSIS_KNOWLEDGE
+        assert "channeling" in ANALYSIS_KNOWLEDGE.lower()
+
+    def test_fact_sheet_renders_stage_classification(self):
+        from analysis_knowledge import build_fact_sheet
+        facts = {
+            "stages": [{
+                "stage_name": "Infusion", "reached": True, "control_mode": "pressure",
+                "trigger_type": "weight",
+                "trigger_class": {"kind": "targeted", "label": "Targeted (yield reached)", "reason": "x"},
+                "stall": {"stalled": False, "weight_gain": 30.0},
+                "channeling": {"channeling": False, "pressure_drop": 0.1, "flow_rise": 0.1},
+                "curve_adherence": {"target": 9.0, "measured": 8.5, "delta": -0.5},
+            }],
+            "phases": [],
+            "weight": {"actual": 36.0, "target": 36.0, "deviation_pct": 0.0},
+            "total_time_s": 30.0,
+        }
+        sheet = build_fact_sheet(facts)
+        assert "Infusion" in sheet
+        assert "Targeted (yield reached)" in sheet
+        assert "36" in sheet
+
+    def test_fact_sheet_flags_stall_and_channeling(self):
+        from analysis_knowledge import build_fact_sheet
+        facts = {
+            "stages": [{
+                "stage_name": "Decline", "reached": True, "control_mode": "pressure",
+                "trigger_type": "time",
+                "trigger_class": {"kind": "failsafe", "label": "Failsafe (timeout limit)", "reason": "x"},
+                "stall": {"stalled": True, "weight_gain": 0.2},
+                "channeling": {"channeling": True, "pressure_drop": 3.0, "flow_rise": 2.0},
+                "curve_adherence": None,
+            }],
+            "phases": [], "weight": {}, "total_time_s": 25.0,
+        }
+        sheet = build_fact_sheet(facts).lower()
+        assert "stall" in sheet
+        assert "channel" in sheet
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestAnalysisKnowledge -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'analysis_knowledge'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/server/analysis_knowledge.py`:
+
+```python
+"""Analysis-specific knowledge base + fact-sheet renderer (K1 + K2).
+
+ANALYSIS_KNOWLEDGE is injected into the shot-analysis prompt (parallel to PROFILING_KNOWLEDGE)
+so small models share the same reasoning framework. build_fact_sheet renders the deterministic
+ShotFacts into compact prose that replaces the raw local-analysis JSON dump in the prompt.
+
+Mirror of apps/web/src/services/ai/analysisKnowledge.ts — keep the two texts in sync.
+"""
+
+from __future__ import annotations
+
+ANALYSIS_KNOWLEDGE = """\
+You are reasoning about a single espresso extraction. Apply this framework:
+
+EXIT TRIGGER CLASSIFICATION (critical — do not confuse intent with failure):
+- A stage ends when one of its exit triggers fires. Classify each as Targeted or Failsafe:
+  - Targeted: the stage reached the outcome it was designed for. Examples: a weight trigger
+    (yield reached), a time trigger that is the stage's ONLY trigger (planned duration), a
+    flow-controlled stage hitting its target pressure (puck resistance achieved), a
+    pressure-controlled stage hitting target pressure, or a pressure-controlled stage whose
+    ONLY trigger is flow (planned flow transition).
+  - Failsafe: a backstop fired before the real target. Examples: a time trigger firing when
+    OTHER triggers also exist (timeout), or a pressure-controlled stage exiting on a flow
+    backstop when other triggers exist (caught channeling or choking).
+- NEVER describe a Targeted exit as a problem. A short stage that hit its weight target is a
+  correct, successful outcome — not "early termination".
+
+DIAGNOSTIC SIGNALS:
+- Stall: a stage exits on a time failsafe with negligible weight gain (< 0.5 g). Indicates the
+  puck choked or flow collapsed. Suggest a coarser grind or revisiting the pressure target.
+- Channeling: pressure falls while flow rises within the same stage. Indicates an uneven puck.
+  Suggest distribution/puck-prep changes, not profile changes, as the first remedy.
+- Curve adherence: when measured average diverges from the stage's target by a meaningful margin,
+  the machine could not follow the profile — usually a grind/dose mismatch, not a profile flaw.
+
+EXTRACTION THEORY:
+- Sour/acidic => under-extraction => grind finer or raise temperature.
+- Bitter/harsh => over-extraction => grind coarser or lower temperature.
+- Weak/thin body => lower brew ratio (less water per dose) or larger dose.
+- Strong/heavy => raise brew ratio.
+
+DISCIPLINE:
+- Only state facts supported by the data provided. Do NOT invent pressures, temperatures, weights,
+  or events that are not in the fact sheet. If a value is unknown, say so.
+- Prefer one or two high-confidence, specific, numeric recommendations over many vague ones.
+"""
+
+
+def _fmt_num(value) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:g}"
+    return str(value)
+
+
+def build_fact_sheet(facts: dict) -> str:
+    """Render ShotFacts into compact prose for the LLM prompt (replaces raw JSON dump)."""
+    lines: list[str] = ["### Deterministic Shot Facts (authoritative — trust over raw telemetry)"]
+
+    weight = facts.get("weight") or {}
+    lines.append(
+        f"- Final weight: {_fmt_num(weight.get('actual'))} g "
+        f"(target {_fmt_num(weight.get('target'))} g, "
+        f"deviation {_fmt_num(weight.get('deviation_pct'))}%)."
+    )
+    lines.append(f"- Total shot time: {_fmt_num(facts.get('total_time_s'))} s.")
+
+    lines.append("- Stage-by-stage:")
+    for s in facts.get("stages", []):
+        if not s.get("reached"):
+            lines.append(f"  - {s.get('stage_name')}: not reached during this shot.")
+            continue
+        tc = s.get("trigger_class") or {}
+        parts = [f"exit = {tc.get('label', 'Unknown')}"]
+        stall = s.get("stall") or {}
+        if stall.get("stalled"):
+            parts.append(f"STALL (only {_fmt_num(stall.get('weight_gain'))} g gained)")
+        chan = s.get("channeling") or {}
+        if chan.get("channeling"):
+            parts.append(
+                f"CHANNELING (pressure -{_fmt_num(chan.get('pressure_drop'))} bar, "
+                f"flow +{_fmt_num(chan.get('flow_rise'))} ml/s)"
+            )
+        ca = s.get("curve_adherence")
+        if ca and abs(float(ca.get("delta", 0) or 0)) >= 0.5:
+            parts.append(f"curve off-target by {_fmt_num(ca.get('delta'))}")
+        lines.append(f"  - {s.get('stage_name')} [{s.get('control_mode')}]: " + "; ".join(parts) + ".")
+
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestAnalysisKnowledge -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/analysis_knowledge.py apps/server/test_main.py
+git commit -m "feat(analysis): add ANALYSIS_KNOWLEDGE + fact-sheet renderer (server)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 8: ANALYSIS_KNOWLEDGE + fact sheet — native (K1 + K2)
+
+**Files:**
+- Create: `apps/web/src/services/ai/analysisKnowledge.ts`
+- Test: `apps/web/src/services/ai/analysisKnowledge.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/services/ai/analysisKnowledge.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { ANALYSIS_KNOWLEDGE, buildFactSheet } from './analysisKnowledge'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+describe('ANALYSIS_KNOWLEDGE', () => {
+  it('covers trigger classes + channeling', () => {
+    expect(ANALYSIS_KNOWLEDGE).toContain('Targeted')
+    expect(ANALYSIS_KNOWLEDGE).toContain('Failsafe')
+    expect(ANALYSIS_KNOWLEDGE.toLowerCase()).toContain('channeling')
+  })
+})
+
+describe('buildFactSheet', () => {
+  const facts: ShotFacts = {
+    stages: [
+      { stage_name: 'Infusion', reached: true, control_mode: 'pressure', trigger_type: 'weight',
+        trigger_class: { kind: 'targeted', label: 'Targeted (yield reached)', reason: '' },
+        stall: { stalled: false, weight_gain: 30 },
+        channeling: { channeling: false, pressure_drop: 0.1, flow_rise: 0.1 },
+        curve_adherence: { target: 9, measured: 8.5, delta: -0.5 } },
+      { stage_name: 'Decline', reached: true, control_mode: 'pressure', trigger_type: 'time',
+        trigger_class: { kind: 'failsafe', label: 'Failsafe (timeout limit)', reason: '' },
+        stall: { stalled: true, weight_gain: 0.2 },
+        channeling: { channeling: true, pressure_drop: 3, flow_rise: 2 },
+        curve_adherence: null },
+    ],
+    phases: [],
+    weight: { actual: 36, target: 36, deviation_pct: 0 },
+    total_time_s: 30,
+  }
+
+  it('renders stage classifications and weight', () => {
+    const sheet = buildFactSheet(facts)
+    expect(sheet).toContain('Infusion')
+    expect(sheet).toContain('Targeted (yield reached)')
+    expect(sheet).toContain('36')
+  })
+
+  it('flags stall and channeling', () => {
+    const sheet = buildFactSheet(facts).toLowerCase()
+    expect(sheet).toContain('stall')
+    expect(sheet).toContain('channel')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/services/ai/analysisKnowledge.test.ts`
+Expected: FAIL — cannot find module `./analysisKnowledge`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/web/src/services/ai/analysisKnowledge.ts`:
+
+```typescript
+/**
+ * Analysis-specific knowledge base + fact-sheet renderer (K1 + K2).
+ * Mirror of apps/server/analysis_knowledge.py — keep the two texts in sync.
+ */
+import type { ShotFacts } from '../../lib/shotFacts'
+
+export const ANALYSIS_KNOWLEDGE = `You are reasoning about a single espresso extraction. Apply this framework:
+
+EXIT TRIGGER CLASSIFICATION (critical — do not confuse intent with failure):
+- A stage ends when one of its exit triggers fires. Classify each as Targeted or Failsafe:
+  - Targeted: the stage reached the outcome it was designed for. Examples: a weight trigger
+    (yield reached), a time trigger that is the stage's ONLY trigger (planned duration), a
+    flow-controlled stage hitting its target pressure (puck resistance achieved), a
+    pressure-controlled stage hitting target pressure, or a pressure-controlled stage whose
+    ONLY trigger is flow (planned flow transition).
+  - Failsafe: a backstop fired before the real target. Examples: a time trigger firing when
+    OTHER triggers also exist (timeout), or a pressure-controlled stage exiting on a flow
+    backstop when other triggers exist (caught channeling or choking).
+- NEVER describe a Targeted exit as a problem. A short stage that hit its weight target is a
+  correct, successful outcome — not "early termination".
+
+DIAGNOSTIC SIGNALS:
+- Stall: a stage exits on a time failsafe with negligible weight gain (< 0.5 g). Indicates the
+  puck choked or flow collapsed. Suggest a coarser grind or revisiting the pressure target.
+- Channeling: pressure falls while flow rises within the same stage. Indicates an uneven puck.
+  Suggest distribution/puck-prep changes, not profile changes, as the first remedy.
+- Curve adherence: when measured average diverges from the stage's target by a meaningful margin,
+  the machine could not follow the profile — usually a grind/dose mismatch, not a profile flaw.
+
+EXTRACTION THEORY:
+- Sour/acidic => under-extraction => grind finer or raise temperature.
+- Bitter/harsh => over-extraction => grind coarser or lower temperature.
+- Weak/thin body => lower brew ratio (less water per dose) or larger dose.
+- Strong/heavy => raise brew ratio.
+
+DISCIPLINE:
+- Only state facts supported by the data provided. Do NOT invent pressures, temperatures, weights,
+  or events that are not in the fact sheet. If a value is unknown, say so.
+- Prefer one or two high-confidence, specific, numeric recommendations over many vague ones.`
+
+const fmtNum = (v: number | null | undefined): string =>
+  v == null ? 'n/a' : (typeof v === 'number' ? `${+v.toFixed(2).replace(/\.?0+$/, '')}` : String(v))
+
+export function buildFactSheet(facts: ShotFacts): string {
+  const lines: string[] = ['### Deterministic Shot Facts (authoritative — trust over raw telemetry)']
+  const w = facts.weight ?? {}
+  lines.push(`- Final weight: ${fmtNum(w.actual)} g (target ${fmtNum(w.target)} g, deviation ${fmtNum(w.deviation_pct)}%).`)
+  lines.push(`- Total shot time: ${fmtNum(facts.total_time_s)} s.`)
+  lines.push('- Stage-by-stage:')
+  for (const s of facts.stages) {
+    if (!s.reached) {
+      lines.push(`  - ${s.stage_name}: not reached during this shot.`)
+      continue
+    }
+    const parts: string[] = [`exit = ${s.trigger_class?.label ?? 'Unknown'}`]
+    if (s.stall?.stalled) parts.push(`STALL (only ${fmtNum(s.stall.weight_gain)} g gained)`)
+    if (s.channeling?.channeling) {
+      parts.push(`CHANNELING (pressure -${fmtNum(s.channeling.pressure_drop)} bar, flow +${fmtNum(s.channeling.flow_rise)} ml/s)`)
+    }
+    if (s.curve_adherence && Math.abs(s.curve_adherence.delta) >= 0.5) {
+      parts.push(`curve off-target by ${fmtNum(s.curve_adherence.delta)}`)
+    }
+    lines.push(`  - ${s.stage_name} [${s.control_mode}]: ${parts.join('; ')}.`)
+  }
+  return lines.join('\n')
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/services/ai/analysisKnowledge.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/services/ai/analysisKnowledge.ts apps/web/src/services/ai/analysisKnowledge.test.ts
+git commit -m "feat(analysis): add ANALYSIS_KNOWLEDGE + fact-sheet renderer (native)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 9: Wire knowledge + fact sheet + few-shot into server prompt (K1/K2/K3)
+
+The route builds the prompt inline (`shots.py` ~991). Tests inspect the captured prompt via the
+mocked model (`async_generate_content.call_args[0][0]`), matching the existing pattern.
+
+**Files:**
+- Modify: `apps/server/analysis_knowledge.py` (add `FEW_SHOT_ANALYSIS_EXAMPLE`)
+- Modify: `apps/server/api/routes/shots.py` (~960–1000)
+- Test: `apps/server/test_main.py` (`TestAnalysisPromptContent`)
+
+- [ ] **Step 1: Add the few-shot constant**
+
+Append to `apps/server/analysis_knowledge.py`:
+
+```python
+FEW_SHOT_ANALYSIS_EXAMPLE = """\
+### Worked Example (format + reasoning reference — do not copy its numbers)
+Facts: Pre-infusion [flow] exit = Targeted (planned duration); Ramp [pressure] exit = Targeted
+(pressure threshold reached); Hold [pressure] exit = Targeted (yield reached); final weight 36 g
+(target 36 g, deviation 0%); total time 28 s.
+
+Good analysis excerpt:
+## 1. Shot Performance
+**What Happened:**
+- Pre-infusion ran its planned duration, then pressure ramped cleanly to target.
+- The hold stage ended exactly on the weight target — a correct, intentional finish.
+**Assessment:** Good
+
+Note how every claim maps to a fact, no values are invented, and the Targeted weight exit is
+described as success, not "early termination".
+"""
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `apps/server/test_main.py`:
+
+```python
+class TestAnalysisPromptContent:
+    @patch("api.routes.shots.get_vision_model")
+    def test_prompt_includes_knowledge_factsheet_fewshot(self, mock_get_model, client, sample_llm_request):
+        """The analyze-llm prompt must carry ANALYSIS_KNOWLEDGE, the fact sheet, and the few-shot."""
+        mock_model = MagicMock()
+        mock_model.async_generate_content = AsyncMock(
+            return_value=MagicMock(text="## 1. Shot Performance\n**What Happened:**\n- ok\n**Assessment:** Good")
+        )
+        mock_get_model.return_value = mock_model
+
+        resp = client.post("/api/shots/analyze-llm", data=sample_llm_request)
+        assert resp.status_code == 200
+        prompt = mock_model.async_generate_content.call_args[0][0]
+        assert "EXIT TRIGGER CLASSIFICATION" in prompt          # ANALYSIS_KNOWLEDGE
+        assert "Deterministic Shot Facts" in prompt              # fact sheet
+        assert "Worked Example" in prompt                        # few-shot
+```
+
+> Reuse the existing analyze-llm request fixture/helper already used by other analyze-llm tests
+> in this file (search for `"/api/shots/analyze-llm"`). If none exists as a fixture, build the
+> `data=` dict inline from the sample shot/profile those tests use, including `profile_name`,
+> `shot_date`, `shot_filename`.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestAnalysisPromptContent -q`
+Expected: FAIL — `assert 'EXIT TRIGGER CLASSIFICATION' in prompt` (knowledge not yet injected)
+
+- [ ] **Step 4: Wire the prompt**
+
+In `apps/server/api/routes/shots.py`, extend the existing knowledge import (line ~34):
+
+```python
+from prompt_builder import PROFILING_KNOWLEDGE  # existing
+from analysis_knowledge import (
+    ANALYSIS_KNOWLEDGE,
+    FEW_SHOT_ANALYSIS_EXAMPLE,
+    build_fact_sheet,
+)
+```
+
+After `local_analysis = _perform_local_shot_analysis(...)` (~962), derive the fact sheet:
+
+```python
+        local_analysis = _perform_local_shot_analysis(shot_data, profile_data)
+        shot_facts = local_analysis.get("shot_facts", {})
+        fact_sheet = build_fact_sheet(shot_facts)
+```
+
+In the prompt f-string, add the analysis framework right after the existing PROFILING_KNOWLEDGE
+block:
+
+```python
+## Expert Knowledge
+{PROFILING_KNOWLEDGE}
+
+## Analysis Framework
+{ANALYSIS_KNOWLEDGE}
+```
+
+Replace the raw local-analysis JSON dump line (`{json.dumps(local_analysis, indent=2)}`) with the
+fact sheet, keeping the surrounding explanatory text:
+
+```python
+## Shot Facts (digested)
+{fact_sheet}
+```
+
+Add the few-shot just before the `Based on this data, provide a detailed expert analysis.` line:
+
+```python
+{FEW_SHOT_ANALYSIS_EXAMPLE}
+
+---
+
+Based on this data, provide a detailed expert analysis.
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestAnalysisPromptContent -q`
+Expected: PASS
+
+- [ ] **Step 6: Run analyze-llm regression group**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py -k "llm or analyze" -q`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/server/analysis_knowledge.py apps/server/api/routes/shots.py apps/server/test_main.py
+git commit -m "feat(analysis): inject knowledge + fact sheet + few-shot into server prompt
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 10: Wire knowledge + fact sheet + few-shot + taste parity into native prompt (K1/K2/K3/K5)
+
+The native DirectMode path (`DirectModeInterceptor.ts` ~3107) currently omits PROFILING_KNOWLEDGE
+AND taste context, and dumps raw `localAnalysis` JSON. Add the analysis framework, fact sheet,
+few-shot, and compass taste section to reach server parity.
+
+**Files:**
+- Modify: `apps/web/src/services/ai/analysisKnowledge.ts` (add `FEW_SHOT_ANALYSIS_EXAMPLE`)
+- Modify: `apps/web/src/services/interceptor/DirectModeInterceptor.ts` (~3051–3140)
+- Test: `apps/web/src/services/interceptor/analyzeLlmPrompt.test.ts`
+
+- [ ] **Step 1: Add the few-shot constant (mirror server)**
+
+Append to `apps/web/src/services/ai/analysisKnowledge.ts`:
+
+```typescript
+export const FEW_SHOT_ANALYSIS_EXAMPLE = `### Worked Example (format + reasoning reference — do not copy its numbers)
+Facts: Pre-infusion [flow] exit = Targeted (planned duration); Ramp [pressure] exit = Targeted
+(pressure threshold reached); Hold [pressure] exit = Targeted (yield reached); final weight 36 g
+(target 36 g, deviation 0%); total time 28 s.
+
+Good analysis excerpt:
+## 1. Shot Performance
+**What Happened:**
+- Pre-infusion ran its planned duration, then pressure ramped cleanly to target.
+- The hold stage ended exactly on the weight target — a correct, intentional finish.
+**Assessment:** Good
+
+Note how every claim maps to a fact, no values are invented, and the Targeted weight exit is
+described as success, not "early termination".`
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web/src/services/interceptor/analyzeLlmPrompt.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { buildAnalyzeLlmPrompt } from './analyzeLlmPrompt'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+const facts: ShotFacts = {
+  stages: [{ stage_name: 'Hold', reached: true, control_mode: 'pressure', trigger_type: 'weight',
+    trigger_class: { kind: 'targeted', label: 'Targeted (yield reached)', reason: '' },
+    stall: { stalled: false, weight_gain: 30 },
+    channeling: { channeling: false, pressure_drop: 0, flow_rise: 0 },
+    curve_adherence: null }],
+  phases: [], weight: { actual: 36, target: 36, deviation_pct: 0 }, total_time_s: 28,
+}
+
+describe('buildAnalyzeLlmPrompt', () => {
+  it('includes knowledge, fact sheet, few-shot', () => {
+    const p = buildAnalyzeLlmPrompt({
+      profileName: 'Test', temperature: 93, targetWeight: 36, profileDescription: 'desc',
+      profileVars: [], cleanStages: [], facts, tasteContext: '',
+    })
+    expect(p).toContain('EXIT TRIGGER CLASSIFICATION')
+    expect(p).toContain('Deterministic Shot Facts')
+    expect(p).toContain('Worked Example')
+  })
+  it('includes taste section when compass taste provided', () => {
+    const p = buildAnalyzeLlmPrompt({
+      profileName: 'Test', temperature: 93, targetWeight: 36, profileDescription: 'desc',
+      profileVars: [], cleanStages: [], facts,
+      tasteContext: '## Taste Goal\nUser wants less sour.',
+    })
+    expect(p).toContain('Taste Goal')
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/services/interceptor/analyzeLlmPrompt.test.ts`
+Expected: FAIL — cannot find module `./analyzeLlmPrompt`
+
+- [ ] **Step 4: Extract the prompt into a testable builder**
+
+Create `apps/web/src/services/interceptor/analyzeLlmPrompt.ts`. Move the long template string
+that currently lives inline at `DirectModeInterceptor.ts:3107` into this pure function, adding the
+three new sections. (Copy the EXISTING template body verbatim, then insert the new blocks marked
+`// NEW`.)
+
+```typescript
+import { ANALYSIS_KNOWLEDGE, FEW_SHOT_ANALYSIS_EXAMPLE, buildFactSheet } from '../ai/analysisKnowledge'
+import type { ShotFacts } from '../../lib/shotFacts'
+
+export interface AnalyzeLlmPromptInput {
+  profileName: string
+  temperature: number | string | null
+  targetWeight: number | string | null
+  profileDescription: string
+  profileVars: unknown[]
+  cleanStages: unknown[]
+  facts: ShotFacts
+  tasteContext: string
+}
+
+export function buildAnalyzeLlmPrompt(input: AnalyzeLlmPromptInput): string {
+  const { profileName, temperature, targetWeight, profileDescription, profileVars, cleanStages, facts, tasteContext } = input
+  return `You are an expert espresso barista and profiling specialist analyzing a shot from a Meticulous Espresso Machine.
+
+## Analysis Framework
+${ANALYSIS_KNOWLEDGE}
+
+## Profile Being Used
+Name: ${profileName}
+Temperature: ${temperature ?? 'Not set'}°C
+Target Weight: ${targetWeight ?? 'Not set'}g
+
+### Profile Description
+${profileDescription || 'No description provided - analyze the profile structure to understand intent.'}
+
+### Profile Variables
+${JSON.stringify(profileVars, null, 2)}
+
+### Profile Stages
+${JSON.stringify(cleanStages, null, 2)}
+
+## Shot Facts (digested)
+${buildFactSheet(facts)}
+${tasteContext ? `\n${tasteContext}\n` : ''}
+${FEW_SHOT_ANALYSIS_EXAMPLE}
+
+---
+
+Based on this data, provide a detailed expert analysis.
+
+CRITICAL FORMATTING RULES:
+1. You MUST use EXACTLY these section headers with the exact format shown (## followed by number, period, space, then title)
+2. Each section MUST have the subsection headers shown (bold text with colon, like **What Happened:**)
+3. ALL content under subsections MUST be bullet points starting with "- "
+4. Keep bullet points concise (1-2 sentences max per bullet)
+5. Do NOT add extra sections or subsections beyond what's specified
+
+## 1. Shot Performance
+
+**What Happened:**
+- [Stage-by-stage description of the extraction]
+- [Notable events: pressure spikes, flow restrictions, early/late stage exits]
+- [Final weight accuracy relative to target]
+
+**Assessment:** [Choose exactly one: Good / Acceptable / Needs Improvement / Problematic]
+
+## 2. Root Cause Analysis
+
+**Primary Factors:**
+- [Most likely cause with brief explanation]
+
+**Secondary Considerations:**
+- [Other contributing factors]
+
+## 3. Setup Recommendations
+
+**Priority Changes:**
+- [Most important change - be specific with numbers when possible]
+
+**Additional Suggestions:**
+- [Other tweaks to consider]
+
+## 4. Profile Recommendations
+
+**Recommended Adjustments:**
+- [Specific profile changes: timing, triggers, targets]
+
+**Reasoning:**
+- [Why these changes would improve the shot]
+
+## 5. Profile Design Observations
+
+**Strengths:**
+- [Well-designed aspects of this profile]
+
+**Potential Improvements:**
+- [Exit trigger or safety limit suggestions]
+
+Focus on actionable insights. Be specific with numbers where possible.
+
+---
+
+INTERNAL INSTRUCTION — Structured Recommendations (do NOT include this heading in your response):
+
+After your analysis sections, you MUST output a structured JSON block with specific, actionable profile variable recommendations.
+Use EXACTLY this format — the markers are parsed programmatically:
+
+RECOMMENDATIONS_JSON:
+[
+  {
+    "variable": "<variable key from the profile>",
+    "current_value": <current numeric value>,
+    "recommended_value": <suggested numeric value>,
+    "stage": "<stage name or 'global'>",
+    "confidence": "<high|medium|low>",
+    "reason": "<one-sentence explanation>"
+  }
+]
+END_RECOMMENDATIONS_JSON
+
+Rules: only include recommendations with a SPECIFIC numeric change; use actual variable keys; if none apply, output an empty array: RECOMMENDATIONS_JSON:\n[]\nEND_RECOMMENDATIONS_JSON`
+}
+```
+
+> Keep the section bodies identical to the current inline template. The goal of this extraction is
+> testability + the three NEW sections (Analysis Framework, Shot Facts, Worked Example) + taste.
+
+- [ ] **Step 5: Call the builder from the interceptor**
+
+In `DirectModeInterceptor.ts`, add imports:
+
+```typescript
+import { buildAnalyzeLlmPrompt } from './analyzeLlmPrompt'
+import { buildTasteContext } from '../ai/prompts'
+```
+
+Replace the inline `const prompt = \`...\`` block (~3107–3228) with a call. Build the taste
+context from the request's compass params if present (the analyze-llm POST body may include
+`taste_x`, `taste_y`, `taste_descriptors` — parse like the server route does; default to empty):
+
+```typescript
+          const tasteX = form.get('taste_x') != null ? Number(form.get('taste_x')) : null
+          const tasteY = form.get('taste_y') != null ? Number(form.get('taste_y')) : null
+          const tasteDescriptors = String(form.get('taste_descriptors') ?? '')
+            .split(',').map(s => s.trim()).filter(Boolean)
+          const tasteContext = (tasteX != null && tasteY != null)
+            ? buildTasteContext(tasteX, tasteY, tasteDescriptors)
+            : ''
+
+          const prompt = buildAnalyzeLlmPrompt({
+            profileName: pName,
+            temperature: shotProfile?.temperature ?? null,
+            targetWeight: shotProfile?.final_weight ?? null,
+            profileDescription,
+            profileVars,
+            cleanStages,
+            facts: buildShotFacts(localAnalysis as Parameters<typeof buildShotFacts>[0]),
+            tasteContext,
+          })
+```
+
+> `buildShotFacts` is already imported from Task 4. If `localAnalysis` here does not already carry
+> `shot_facts`, compute it inline as shown. Ensure `form` is the parsed FormData already in scope
+> in this handler (it is used for profile/shot lookup nearby).
+
+- [ ] **Step 6: Run tests + interceptor regression**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/services/interceptor/analyzeLlmPrompt.test.ts src/services/interceptor`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/services/ai/analysisKnowledge.ts apps/web/src/services/interceptor/analyzeLlmPrompt.ts apps/web/src/services/interceptor/analyzeLlmPrompt.test.ts apps/web/src/services/interceptor/DirectModeInterceptor.ts
+git commit -m "feat(analysis): native prompt parity — knowledge, fact sheet, few-shot, compass taste
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 11: Anti-hallucination / semantic validator — native (K4)
+
+Add a fact-aware validator that rejects analyses contradicting the deterministic ShotFacts (e.g.
+calling a Targeted weight exit an "early termination"). High-precision checks only — false
+positives force needless regeneration. Wire into both native analysis paths with retry+repair
+(DirectMode currently returns raw, unvalidated text).
+
+**Files:**
+- Modify: `apps/web/src/lib/analysisLint.ts` (add `validateAgainstFacts`)
+- Test: `apps/web/src/lib/analysisLint.test.ts` (append)
+- Modify: `apps/web/src/services/interceptor/DirectModeInterceptor.ts` (validate response ~3238)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/web/src/lib/analysisLint.test.ts` (create the file if it does not exist, importing
+from `./analysisLint`):
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { validateAgainstFacts } from './analysisLint'
+import type { ShotFacts } from './shotFacts'
+
+const factsTargetedWeight: ShotFacts = {
+  stages: [{ stage_name: 'Hold', reached: true, control_mode: 'pressure', trigger_type: 'weight',
+    trigger_class: { kind: 'targeted', label: 'Targeted (yield reached)', reason: '' },
+    stall: { stalled: false, weight_gain: 30 },
+    channeling: { channeling: false, pressure_drop: 0, flow_rise: 0 },
+    curve_adherence: null }],
+  phases: [], weight: { actual: 36, target: 36, deviation_pct: 0 }, total_time_s: 28,
+}
+
+describe('validateAgainstFacts (K4)', () => {
+  it('flags a targeted weight exit described as early termination', () => {
+    const text = '## 1. Shot Performance\n- The hold stage terminated early before reaching its goal.'
+    const r = validateAgainstFacts(text, factsTargetedWeight)
+    expect(r.valid).toBe(false)
+    expect(r.issues).toContain('mischaracterized-targeted-exit')
+  })
+  it('accepts analysis that frames the targeted exit as success', () => {
+    const text = '## 1. Shot Performance\n- The hold stage ended exactly on the weight target, a correct finish.'
+    expect(validateAgainstFacts(text, factsTargetedWeight).valid).toBe(true)
+  })
+  it('flags channeling claimed when no stage channeled', () => {
+    const text = '## 2. Root Cause\n- Severe channeling caused the pressure to collapse.'
+    const r = validateAgainstFacts(text, factsTargetedWeight)
+    expect(r.issues).toContain('unsupported-channeling')
+  })
+  it('does not flag channeling when a stage actually channeled', () => {
+    const facts: ShotFacts = { ...factsTargetedWeight, stages: [{ ...factsTargetedWeight.stages[0],
+      channeling: { channeling: true, pressure_drop: 3, flow_rise: 2 } }] }
+    const text = '- Channeling is evident from the pressure drop.'
+    expect(validateAgainstFacts(text, facts).issues).not.toContain('unsupported-channeling')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/analysisLint.test.ts`
+Expected: FAIL — `validateAgainstFacts` is not exported
+
+- [ ] **Step 3: Implement the validator**
+
+Append to `apps/web/src/lib/analysisLint.ts`:
+
+```typescript
+import type { ShotFacts } from './shotFacts'
+
+/** Phrases that frame a stage exit as a failure/early stop. */
+const EARLY_EXIT_PATTERNS = [
+  /terminat\w*\s+early/i,
+  /\bearly\s+terminat/i,
+  /ended?\s+(too\s+)?(early|prematurely)/i,
+  /\bcut\s+short\b/i,
+  /stopped?\s+before\s+reaching/i,
+]
+/** Phrases asserting channeling occurred. */
+const CHANNELING_ASSERTION = /\bchannel(?:ing|ed|s)?\b/i
+/** Phrases that negate channeling (so we don't flag "no channeling"). */
+const CHANNELING_NEGATION = /\b(no|not|without|absence of|isn'?t|wasn'?t)\b[^.]{0,30}channel/i
+
+/**
+ * Reject analyses that contradict the deterministic ShotFacts. High precision:
+ * only flags clear, well-supported contradictions.
+ */
+export function validateAgainstFacts(text: string, facts: ShotFacts): AnalysisLintResult {
+  const issues: string[] = []
+  const body = text ?? ''
+
+  const hasTargetedWeightExit = facts.stages.some(
+    s => s.reached && s.trigger_type === 'weight' && s.trigger_class?.kind === 'targeted',
+  )
+  if (hasTargetedWeightExit && EARLY_EXIT_PATTERNS.some(re => re.test(body))) {
+    issues.push('mischaracterized-targeted-exit')
+  }
+
+  const anyChanneling = facts.stages.some(s => s.channeling?.channeling)
+  if (!anyChanneling && CHANNELING_ASSERTION.test(body) && !CHANNELING_NEGATION.test(body)) {
+    issues.push('unsupported-channeling')
+  }
+
+  return { valid: issues.length === 0, issues }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/analysisLint.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Wire validation into DirectMode (retry once, then repair)**
+
+In `DirectModeInterceptor.ts`, locate the analyze-llm response handling (~3231–3242) where it
+currently returns `analysisText` raw. Replace with validate → retry → repair:
+
+```typescript
+          const analyzeProvider = getProviderForMethod('analyzeShot')
+          const facts = buildShotFacts(localAnalysis as Parameters<typeof buildShotFacts>[0])
+          const gen = async () => {
+            const r = await retryWithBackoff(() => analyzeProvider.generateText({
+              contents: [{ role: 'user', parts: [{ text: prompt }] }],
+            })) as { text?: string }
+            return r.text ?? ''
+          }
+          let analysisText = await gen()
+          let lint = lintShotAnalysis(analysisText)
+          let factCheck = validateAgainstFacts(analysisText, facts)
+          if (!lint.valid || !factCheck.valid) {
+            analysisText = await gen()  // one retry
+            lint = lintShotAnalysis(analysisText)
+            factCheck = validateAgainstFacts(analysisText, facts)
+          }
+          if (!lint.valid) analysisText = repairShotAnalysis(analysisText)
+          return jsonResponse({ status: 'success', llm_analysis: analysisText, cached: false })
+```
+
+Add the imports at the top of the file if not already present:
+
+```typescript
+import { lintShotAnalysis, repairShotAnalysis, validateAgainstFacts } from '../../lib/analysisLint'
+```
+
+- [ ] **Step 6: Run interceptor tests**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/services/interceptor src/lib/analysisLint.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/lib/analysisLint.ts apps/web/src/lib/analysisLint.test.ts apps/web/src/services/interceptor/DirectModeInterceptor.ts
+git commit -m "feat(analysis): add anti-hallucination validator + wire native retry/repair (K4)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 12: Anti-hallucination validator — server (K4 parity)
+
+**Files:**
+- Create: `apps/server/services/analysis_validator.py`
+- Modify: `apps/server/api/routes/shots.py` (validate `llm_analysis` after generation, ~1131)
+- Test: `apps/server/test_main.py` (`TestAnalysisValidator`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/server/test_main.py`:
+
+```python
+class TestAnalysisValidator:
+    def _facts_targeted_weight(self):
+        return {
+            "stages": [{
+                "stage_name": "Hold", "reached": True, "control_mode": "pressure",
+                "trigger_type": "weight",
+                "trigger_class": {"kind": "targeted", "label": "Targeted (yield reached)", "reason": ""},
+                "stall": {"stalled": False, "weight_gain": 30.0},
+                "channeling": {"channeling": False, "pressure_drop": 0.0, "flow_rise": 0.0},
+                "curve_adherence": None,
+            }],
+            "phases": [], "weight": {"actual": 36.0, "target": 36.0, "deviation_pct": 0.0},
+            "total_time_s": 28.0,
+        }
+
+    def test_flags_targeted_exit_called_early_termination(self):
+        from services.analysis_validator import validate_against_facts
+        text = "- The hold stage terminated early before reaching its goal."
+        r = validate_against_facts(text, self._facts_targeted_weight())
+        assert r["valid"] is False
+        assert "mischaracterized-targeted-exit" in r["issues"]
+
+    def test_accepts_success_framing(self):
+        from services.analysis_validator import validate_against_facts
+        text = "- The hold stage ended exactly on the weight target, a correct finish."
+        assert validate_against_facts(text, self._facts_targeted_weight())["valid"] is True
+
+    def test_flags_unsupported_channeling(self):
+        from services.analysis_validator import validate_against_facts
+        text = "- Severe channeling caused the pressure to collapse."
+        assert "unsupported-channeling" in validate_against_facts(text, self._facts_targeted_weight())["issues"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestAnalysisValidator -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'services.analysis_validator'`
+
+- [ ] **Step 3: Implement (mirror of native)**
+
+Create `apps/server/services/analysis_validator.py`:
+
+```python
+"""Anti-hallucination / semantic validator for shot-analysis output (K4 server parity).
+
+Mirror of validateAgainstFacts in apps/web/src/lib/analysisLint.ts — keep rules identical.
+High precision: only flag clear contradictions of the deterministic ShotFacts.
+"""
+
+from __future__ import annotations
+
+import re
+
+_EARLY_EXIT_PATTERNS = [
+    re.compile(r"terminat\w*\s+early", re.I),
+    re.compile(r"\bearly\s+terminat", re.I),
+    re.compile(r"ended?\s+(too\s+)?(early|prematurely)", re.I),
+    re.compile(r"\bcut\s+short\b", re.I),
+    re.compile(r"stopped?\s+before\s+reaching", re.I),
+]
+_CHANNELING_ASSERTION = re.compile(r"\bchannel(?:ing|ed|s)?\b", re.I)
+_CHANNELING_NEGATION = re.compile(r"\b(no|not|without|absence of|isn'?t|wasn'?t)\b[^.]{0,30}channel", re.I)
+
+
+def validate_against_facts(text: str, facts: dict) -> dict:
+    """Return {'valid': bool, 'issues': list[str]}."""
+    issues: list[str] = []
+    body = text or ""
+    stages = facts.get("stages", [])
+
+    has_targeted_weight_exit = any(
+        s.get("reached")
+        and s.get("trigger_type") == "weight"
+        and (s.get("trigger_class") or {}).get("kind") == "targeted"
+        for s in stages
+    )
+    if has_targeted_weight_exit and any(p.search(body) for p in _EARLY_EXIT_PATTERNS):
+        issues.append("mischaracterized-targeted-exit")
+
+    any_channeling = any((s.get("channeling") or {}).get("channeling") for s in stages)
+    if not any_channeling and _CHANNELING_ASSERTION.search(body) and not _CHANNELING_NEGATION.search(body):
+        issues.append("unsupported-channeling")
+
+    return {"valid": len(issues) == 0, "issues": issues}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestAnalysisValidator -q`
+Expected: PASS
+
+- [ ] **Step 5: Wire into the route (validate → one retry)**
+
+In `apps/server/api/routes/shots.py`, add the import (~34 block):
+
+```python
+from services.analysis_validator import validate_against_facts
+```
+
+Replace the single generation (~1129–1131):
+
+```python
+        response = await model.async_generate_content(prompt)
+        llm_analysis = response.text if response else "Analysis generation failed"
+        if not validate_against_facts(llm_analysis, shot_facts)["valid"]:
+            retry = await model.async_generate_content(prompt)
+            retry_text = retry.text if retry else llm_analysis
+            if validate_against_facts(retry_text, shot_facts)["valid"]:
+                llm_analysis = retry_text
+```
+
+> `shot_facts` is already in scope from Task 9. The retry is best-effort — keep the first result
+> if the retry is also invalid (no hard failure for the user).
+
+- [ ] **Step 6: Run regression**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py -k "Validator or llm or analyze" -q`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/server/services/analysis_validator.py apps/server/api/routes/shots.py apps/server/test_main.py
+git commit -m "feat(analysis): add anti-hallucination validator + route retry (server K4)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+**Phase 2 complete.** Both runtimes now share a knowledge base, a digested fact sheet, a few-shot
+example, compass taste parity, and a fact-aware validator with retry/repair.
+
+---
+
+## Phase 3 — Espresso Compass UX (U1–U3)
+
+The `analyze-llm` endpoint already accepts `taste_x` / `taste_y` / `taste_descriptors` (server
+route + native interceptor wired in Task 10). Phase 3 adds the optional pre-analysis step that
+collects taste, threads it into the request, persists it with the shot, and surfaces the
+deterministic compass adjustments alongside the AI output.
+
+### Task 13: Optional skippable compass step before analysis (U1)
+
+Reuse the existing `TasteCompassInput` (`apps/web/src/components/TasteCompassInput.tsx`,
+`TasteData` / `DEFAULT_TASTE_DATA`). A small gate component offers "Analyze with taste" or "Skip".
+
+**Files:**
+- Create: `apps/web/src/components/ShotHistoryView/AnalysisTasteGate.tsx`
+- Create: `apps/web/src/components/ShotHistoryView/AnalysisTasteGate.test.tsx`
+- Modify: `apps/web/public/locales/{en,sv,de,es,fr,it}/translation.json`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/ShotHistoryView/AnalysisTasteGate.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AnalysisTasteGate } from './AnalysisTasteGate'
+import { DEFAULT_TASTE_DATA } from '../TasteCompassInput'
+
+describe('AnalysisTasteGate (U1)', () => {
+  it('calls onSkip when the user skips', () => {
+    const onSkip = vi.fn()
+    render(<AnalysisTasteGate onAnalyze={vi.fn()} onSkip={onSkip} />)
+    fireEvent.click(screen.getByTestId('taste-gate-skip'))
+    expect(onSkip).toHaveBeenCalledTimes(1)
+  })
+  it('calls onAnalyze with current taste data', () => {
+    const onAnalyze = vi.fn()
+    render(<AnalysisTasteGate onAnalyze={onAnalyze} onSkip={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('taste-gate-analyze'))
+    expect(onAnalyze).toHaveBeenCalledWith(DEFAULT_TASTE_DATA)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/components/ShotHistoryView/AnalysisTasteGate.test.tsx`
+Expected: FAIL — cannot find module `./AnalysisTasteGate`
+
+- [ ] **Step 3: Implement the gate**
+
+Create `apps/web/src/components/ShotHistoryView/AnalysisTasteGate.tsx`:
+
+```typescript
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '../ui/button'
+import { TasteCompassInput, DEFAULT_TASTE_DATA, type TasteData } from '../TasteCompassInput'
+
+interface Props {
+  onAnalyze: (taste: TasteData) => void
+  onSkip: () => void
+  initialTaste?: TasteData
+}
+
+export function AnalysisTasteGate({ onAnalyze, onSkip, initialTaste }: Props) {
+  const { t } = useTranslation()
+  const [taste, setTaste] = useState<TasteData>(initialTaste ?? DEFAULT_TASTE_DATA)
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-4">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-foreground">{t('analysis.taste.gateTitle')}</h3>
+        <p className="text-xs text-muted-foreground">{t('analysis.taste.gateBody')}</p>
+      </div>
+      <TasteCompassInput value={taste} onChange={setTaste} />
+      <div className="flex gap-2 justify-end">
+        <Button variant="ghost" data-testid="taste-gate-skip" onClick={onSkip}>
+          {t('analysis.taste.skip')}
+        </Button>
+        <Button data-testid="taste-gate-analyze" onClick={() => onAnalyze(taste)}>
+          {t('analysis.taste.analyzeWithTaste')}
+        </Button>
+      </div>
+    </div>
+  )
+}
+```
+
+> Verify the `Button` import path matches the project (`../ui/button`). If `TasteCompassInput`
+> does not re-export `TasteData` / `DEFAULT_TASTE_DATA`, import them from their definition (they
+> are exported from `TasteCompassInput.tsx` per the file's exports).
+
+- [ ] **Step 4: Add i18n keys (all 6 locales)** — merge into the `analysis` object from Task 5.
+
+`en`:
+```json
+"taste": {
+  "gateTitle": "Refine with taste (optional)",
+  "gateBody": "Tell the analysis how this shot tasted for sharper, taste-aware recommendations.",
+  "skip": "Skip",
+  "analyzeWithTaste": "Analyze with taste"
+}
+```
+`sv`:
+```json
+"taste": { "gateTitle": "Förfina med smak (valfritt)", "gateBody": "Berätta hur koppen smakade för smakmedvetna rekommendationer.", "skip": "Hoppa över", "analyzeWithTaste": "Analysera med smak" }
+```
+`de`:
+```json
+"taste": { "gateTitle": "Mit Geschmack verfeinern (optional)", "gateBody": "Teile mit, wie der Shot geschmeckt hat, für geschmacksbewusste Empfehlungen.", "skip": "Überspringen", "analyzeWithTaste": "Mit Geschmack analysieren" }
+```
+`es`:
+```json
+"taste": { "gateTitle": "Refinar con el sabor (opcional)", "gateBody": "Indica a qué supo este shot para recomendaciones más precisas.", "skip": "Omitir", "analyzeWithTaste": "Analizar con el sabor" }
+```
+`fr`:
+```json
+"taste": { "gateTitle": "Affiner avec le goût (facultatif)", "gateBody": "Indiquez le goût de cette extraction pour des recommandations plus fines.", "skip": "Ignorer", "analyzeWithTaste": "Analyser avec le goût" }
+```
+`it`:
+```json
+"taste": { "gateTitle": "Affina con il gusto (facoltativo)", "gateBody": "Indica com'era il gusto per consigli più mirati.", "skip": "Salta", "analyzeWithTaste": "Analizza con il gusto" }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/components/ShotHistoryView/AnalysisTasteGate.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/ShotHistoryView/AnalysisTasteGate.tsx apps/web/src/components/ShotHistoryView/AnalysisTasteGate.test.tsx apps/web/public/locales
+git commit -m "feat(analysis): add optional compass taste gate before AI analysis (U1)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 14: Thread taste into analysis, persist it, dual-feed deterministic adjustments (U2 + U3)
+
+Wire the gate into `ShotDetail.tsx`: show it before triggering `analyze-llm`, pass taste into the
+request, persist the last taste per shot, and render deterministic compass adjustments in the
+static panel (dual feed).
+
+**Files:**
+- Create: `apps/web/src/lib/shotTasteStore.ts`
+- Create: `apps/web/src/lib/shotTasteStore.test.ts`
+- Modify: `apps/web/src/components/ShotHistoryView/ShotDetail.tsx` (gate + request + persist)
+- Modify: `apps/web/src/components/ShotHistoryView/ShotFactsPanel.tsx` (render adjustments)
+- Modify: `apps/web/src/components/ShotHistoryView/ShotFactsPanel.test.tsx` (assert adjustments)
+
+- [ ] **Step 1: Write the failing store test**
+
+Create `apps/web/src/lib/shotTasteStore.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest'
+import { saveShotTaste, loadShotTaste, shotTasteKey } from './shotTasteStore'
+
+describe('shotTasteStore (U3)', () => {
+  beforeEach(() => localStorage.clear())
+  it('round-trips taste for a shot key', () => {
+    const taste = { x: -0.5, y: 0.3, descriptors: ['sour'] }
+    saveShotTaste('Prof', '2024-01-01', 'a.json', taste)
+    expect(loadShotTaste('Prof', '2024-01-01', 'a.json')).toEqual(taste)
+  })
+  it('returns null when nothing stored', () => {
+    expect(loadShotTaste('Prof', '2024-01-01', 'missing.json')).toBeNull()
+  })
+  it('builds a stable composite key', () => {
+    expect(shotTasteKey('P', 'd', 'f')).toBe('shot-taste:P|d|f')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/shotTasteStore.test.ts`
+Expected: FAIL — cannot find module `./shotTasteStore`
+
+- [ ] **Step 3: Implement the store**
+
+Create `apps/web/src/lib/shotTasteStore.ts`:
+
+```typescript
+/** Persist the compass taste a user supplied for a given shot (U3). */
+
+export interface StoredTaste {
+  x: number
+  y: number
+  descriptors: string[]
+}
+
+export function shotTasteKey(profileName: string, date: string, filename: string): string {
+  return `shot-taste:${profileName}|${date}|${filename}`
+}
+
+export function saveShotTaste(profileName: string, date: string, filename: string, taste: StoredTaste): void {
+  try {
+    localStorage.setItem(shotTasteKey(profileName, date, filename), JSON.stringify(taste))
+  } catch {
+    // storage unavailable (private mode / quota) — non-critical
+  }
+}
+
+export function loadShotTaste(profileName: string, date: string, filename: string): StoredTaste | null {
+  try {
+    const raw = localStorage.getItem(shotTasteKey(profileName, date, filename))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredTaste
+    if (typeof parsed.x === 'number' && typeof parsed.y === 'number' && Array.isArray(parsed.descriptors)) {
+      return parsed
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/shotTasteStore.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Render deterministic adjustments in ShotFactsPanel (U2 dual-feed)**
+
+Extend `ShotFactsPanel.test.tsx` with a new case:
+
+```typescript
+it('renders compass adjustments when taste is provided', () => {
+  render(<ShotFactsPanel facts={facts} taste={{ x: -0.8, y: -0.6, descriptors: [] }} />)
+  expect(screen.getByText('analysis.facts.adjustmentsTitle')).toBeInTheDocument()
+  expect(screen.getByText(/grind_finer/i)).toBeInTheDocument()
+})
+```
+
+Update `ShotFactsPanel.tsx` to accept an optional `taste` prop and render
+`compassAdjustments(taste.x, taste.y)`:
+
+```typescript
+import { compassAdjustments } from '../../lib/compassRules'
+import type { StoredTaste } from '../../lib/shotTasteStore'
+
+interface Props {
+  facts: ShotFacts
+  taste?: StoredTaste | null
+}
+
+// inside the component, after the stages <ul>...</ul>:
+{taste && (() => {
+  const adj = compassAdjustments(taste.x, taste.y)
+  if (adj.length === 0) return null
+  return (
+    <div className="space-y-1">
+      <h4 className="text-xs font-semibold text-foreground">{t('analysis.facts.adjustmentsTitle')}</h4>
+      <ul className="space-y-1">
+        {adj.map((a, i) => (
+          <li key={`${a.kind}-${i}`} className="text-xs text-muted-foreground">
+            <span className="font-mono">{a.kind}</span> — {a.reason}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+})()}
+```
+
+Add the `analysis.facts.adjustmentsTitle` key to all 6 locales (merge into the `facts` block):
+- en: `"adjustmentsTitle": "Suggested adjustments"`
+- sv: `"adjustmentsTitle": "Föreslagna justeringar"`
+- de: `"adjustmentsTitle": "Vorgeschlagene Anpassungen"`
+- es: `"adjustmentsTitle": "Ajustes sugeridos"`
+- fr: `"adjustmentsTitle": "Ajustements suggérés"`
+- it: `"adjustmentsTitle": "Regolazioni suggerite"`
+
+- [ ] **Step 6: Wire the gate + persistence into ShotDetail**
+
+In `ShotDetail.tsx`:
+
+Add imports:
+```typescript
+import { AnalysisTasteGate } from './AnalysisTasteGate'
+import { saveShotTaste, loadShotTaste, type StoredTaste } from '../../lib/shotTasteStore'
+import type { TasteData } from '../TasteCompassInput'
+```
+
+Add state:
+```typescript
+const [showTasteGate, setShowTasteGate] = useState(false)
+const [shotTaste, setShotTaste] = useState<StoredTaste | null>(null)
+```
+
+When the user requests AI analysis (the button that currently calls `handleLlmAnalysis`), first
+show the gate instead. Replace the button's `onClick={handleLlmAnalysis}` with
+`onClick={() => setShowTasteGate(true)}` and render the gate when `showTasteGate`:
+
+```tsx
+{showTasteGate && (
+  <AnalysisTasteGate
+    initialTaste={shotTaste ? { x: shotTaste.x, y: shotTaste.y, descriptors: shotTaste.descriptors } as TasteData : undefined}
+    onSkip={() => { setShowTasteGate(false); handleLlmAnalysis(null) }}
+    onAnalyze={(taste) => {
+      const stored: StoredTaste = { x: taste.x, y: taste.y, descriptors: taste.descriptors ?? [] }
+      setShotTaste(stored)
+      if (selectedShot) saveShotTaste(profileName, selectedShot.date, selectedShot.filename, stored)
+      setShowTasteGate(false)
+      handleLlmAnalysis(stored)
+    }}
+  />
+)}
+```
+
+Change `handleLlmAnalysis` to accept optional taste and append it to the request:
+```typescript
+const handleLlmAnalysis = async (taste: StoredTaste | null) => {
+  // ... existing setup ...
+  if (taste) {
+    formData.append('taste_x', String(taste.x))
+    formData.append('taste_y', String(taste.y))
+    if (taste.descriptors.length) formData.append('taste_descriptors', taste.descriptors.join(','))
+  }
+  // ... existing fetch ...
+}
+```
+
+Load any persisted taste when the shot changes (so re-analysis pre-fills it):
+```typescript
+useEffect(() => {
+  if (selectedShot) setShotTaste(loadShotTaste(profileName, selectedShot.date, selectedShot.filename))
+}, [selectedShot, profileName])
+```
+
+Pass `taste={shotTaste}` to the `<ShotFactsPanel ... />` mounted in Task 5.
+
+> `TasteData` uses `x` / `y` / `descriptors` (confirm field names against
+> `TasteCompassInput.tsx`'s `TasteData` interface; adjust the mapping if the axis fields differ).
+
+- [ ] **Step 7: Run the affected tests + types + lint**
+
+Run:
+```bash
+cd apps/web && bun run test:run -- --reporter=dot src/lib/shotTasteStore.test.ts src/components/ShotHistoryView/ShotFactsPanel.test.tsx src/components/ShotHistoryView/AnalysisTasteGate.test.tsx
+npx tsc --noEmit 2>&1 | grep -v "useGenerationProgress.ts:94\|test/setup.ts:57" | grep "error TS" || echo "tsc baseline OK"
+bunx eslint src/components/ShotHistoryView/ShotFactsPanel.tsx src/components/ShotHistoryView/ShotDetail.tsx src/lib/shotTasteStore.ts
+```
+Expected: tests PASS, no new tsc errors, eslint clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/lib/shotTasteStore.ts apps/web/src/lib/shotTasteStore.test.ts apps/web/src/components/ShotHistoryView/ShotFactsPanel.tsx apps/web/src/components/ShotHistoryView/ShotFactsPanel.test.tsx apps/web/src/components/ShotHistoryView/ShotDetail.tsx apps/web/public/locales
+git commit -m "feat(analysis): thread compass taste into analysis, persist + dual-feed (U2/U3)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+**Phase 3 complete.** The compass is an optional skippable pre-analysis step; taste is threaded
+to the AI, persisted with the shot, and its deterministic adjustments are shown in the static view.
+
+---
+
+## Phase 4 — Format-Aware Linting (L1–L5)
+
+Today's linter (`analysisLint.ts`) only catches degeneracy (empty/repetition/low-diversity).
+Phase 4 makes it format-aware (required sections present), defines the section schema once per
+runtime (single source consumed by both prompt + linter), ensures every analysis path runs the
+full check (universal wiring), and adds a release-gate coverage-matrix test.
+
+### Task 15: Single-source schema + format-aware structural lint — native (L1 + L2)
+
+**Files:**
+- Create: `apps/web/src/lib/analysisSchema.ts`
+- Modify: `apps/web/src/lib/analysisLint.ts` (add `checkStructure`)
+- Modify: `apps/web/src/lib/analysisLint.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/web/src/lib/analysisLint.test.ts`:
+
+```typescript
+import { checkStructure } from './analysisLint'
+import { REQUIRED_ANALYSIS_SECTIONS } from './analysisSchema'
+
+describe('checkStructure (L1) + schema (L2)', () => {
+  it('schema lists the five core sections', () => {
+    expect(REQUIRED_ANALYSIS_SECTIONS).toContain('Shot Performance')
+    expect(REQUIRED_ANALYSIS_SECTIONS.length).toBeGreaterThanOrEqual(5)
+  })
+  it('flags missing required sections', () => {
+    const r = checkStructure('## 1. Shot Performance\n- ok')
+    expect(r.valid).toBe(false)
+    expect(r.issues).toContain('missing-sections')
+  })
+  it('accepts text containing all required section titles', () => {
+    const text = REQUIRED_ANALYSIS_SECTIONS.map((s, i) => `## ${i + 1}. ${s}\n- content line here`).join('\n')
+    expect(checkStructure(text).valid).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/analysisLint.test.ts`
+Expected: FAIL — cannot find module `./analysisSchema`
+
+- [ ] **Step 3: Create the schema**
+
+Create `apps/web/src/lib/analysisSchema.ts`:
+
+```typescript
+/**
+ * Single source of truth for the shot-analysis section structure (L2).
+ * Consumed by the prompt builders and the structural linter so the format the model is asked
+ * to produce and the format we validate can never drift apart.
+ * Mirror of apps/server/analysis_schema.py.
+ */
+
+export const REQUIRED_ANALYSIS_SECTIONS = [
+  'Shot Performance',
+  'Root Cause Analysis',
+  'Setup Recommendations',
+  'Profile Recommendations',
+  'Profile Design Observations',
+] as const
+
+/** Optional taste section appended when compass taste is supplied. */
+export const OPTIONAL_TASTE_SECTION = 'Taste-Based Recommendations'
+```
+
+- [ ] **Step 4: Add the structural check**
+
+Append to `apps/web/src/lib/analysisLint.ts`:
+
+```typescript
+import { REQUIRED_ANALYSIS_SECTIONS } from './analysisSchema'
+
+/**
+ * Verify the analysis contains each required section title (L1). Matches on the title text so
+ * it is robust to numbering/heading-level variations the model may introduce.
+ */
+export function checkStructure(text: string): AnalysisLintResult {
+  const body = (text ?? '').toLowerCase()
+  const missing = REQUIRED_ANALYSIS_SECTIONS.filter(s => !body.includes(s.toLowerCase()))
+  return { valid: missing.length === 0, issues: missing.length ? ['missing-sections'] : [] }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/analysisLint.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/lib/analysisSchema.ts apps/web/src/lib/analysisLint.ts apps/web/src/lib/analysisLint.test.ts
+git commit -m "feat(analysis): add single-source section schema + structural lint (native L1/L2)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 16: Schema + structural lint parity + universal wiring — server & all native paths (L2/L1/L3)
+
+**Files:**
+- Create: `apps/server/analysis_schema.py`
+- Modify: `apps/server/services/analysis_validator.py` (add `check_structure`, fold into `validate_against_facts` callers)
+- Modify: `apps/server/api/routes/shots.py` (run structural check in the retry gate)
+- Modify: `apps/web/src/services/interceptor/DirectModeInterceptor.ts` (add `checkStructure` to the gate)
+- Test: `apps/server/test_main.py` (`TestAnalysisStructure`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/server/test_main.py`:
+
+```python
+class TestAnalysisStructure:
+    def test_schema_lists_core_sections(self):
+        from analysis_schema import REQUIRED_ANALYSIS_SECTIONS
+        assert "Shot Performance" in REQUIRED_ANALYSIS_SECTIONS
+        assert len(REQUIRED_ANALYSIS_SECTIONS) >= 5
+
+    def test_check_structure_flags_missing_sections(self):
+        from services.analysis_validator import check_structure
+        r = check_structure("## 1. Shot Performance\n- ok")
+        assert r["valid"] is False
+        assert "missing-sections" in r["issues"]
+
+    def test_check_structure_accepts_full_text(self):
+        from analysis_schema import REQUIRED_ANALYSIS_SECTIONS
+        from services.analysis_validator import check_structure
+        text = "\n".join(f"## {i+1}. {s}\n- content" for i, s in enumerate(REQUIRED_ANALYSIS_SECTIONS))
+        assert check_structure(text)["valid"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestAnalysisStructure -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'analysis_schema'`
+
+- [ ] **Step 3: Create the schema + structural check (server)**
+
+Create `apps/server/analysis_schema.py`:
+
+```python
+"""Single source of truth for the shot-analysis section structure (L2).
+
+Mirror of apps/web/src/lib/analysisSchema.ts — keep section titles identical.
+"""
+
+from __future__ import annotations
+
+REQUIRED_ANALYSIS_SECTIONS = [
+    "Shot Performance",
+    "Root Cause Analysis",
+    "Setup Recommendations",
+    "Profile Recommendations",
+    "Profile Design Observations",
+]
+
+OPTIONAL_TASTE_SECTION = "Taste-Based Recommendations"
+```
+
+Append to `apps/server/services/analysis_validator.py`:
+
+```python
+from analysis_schema import REQUIRED_ANALYSIS_SECTIONS
+
+
+def check_structure(text: str) -> dict:
+    """Verify the analysis contains each required section title (L1)."""
+    body = (text or "").lower()
+    missing = [s for s in REQUIRED_ANALYSIS_SECTIONS if s.lower() not in body]
+    return {"valid": not missing, "issues": ["missing-sections"] if missing else []}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestAnalysisStructure -q`
+Expected: PASS
+
+- [ ] **Step 5: Fold structural check into the route gate (server L3)**
+
+In `apps/server/api/routes/shots.py`, update the import:
+
+```python
+from services.analysis_validator import validate_against_facts, check_structure
+```
+
+Extend the retry condition added in Task 12 so structure is also enforced:
+
+```python
+        response = await model.async_generate_content(prompt)
+        llm_analysis = response.text if response else "Analysis generation failed"
+        first_ok = (
+            validate_against_facts(llm_analysis, shot_facts)["valid"]
+            and check_structure(llm_analysis)["valid"]
+        )
+        if not first_ok:
+            retry = await model.async_generate_content(prompt)
+            retry_text = retry.text if retry else llm_analysis
+            if (
+                validate_against_facts(retry_text, shot_facts)["valid"]
+                and check_structure(retry_text)["valid"]
+            ):
+                llm_analysis = retry_text
+```
+
+- [ ] **Step 6: Fold structural check into the native DirectMode gate (L3)**
+
+In `DirectModeInterceptor.ts`, extend the import:
+
+```typescript
+import { lintShotAnalysis, repairShotAnalysis, validateAgainstFacts, checkStructure } from '../../lib/analysisLint'
+```
+
+In the validate→retry block from Task 11, include structure:
+
+```typescript
+          let analysisText = await gen()
+          const ok = (txt: string) =>
+            lintShotAnalysis(txt).valid && validateAgainstFacts(txt, facts).valid && checkStructure(txt).valid
+          if (!ok(analysisText)) {
+            const retry = await gen()
+            if (ok(retry)) analysisText = retry
+          }
+          if (!lintShotAnalysis(analysisText).valid) analysisText = repairShotAnalysis(analysisText)
+          return jsonResponse({ status: 'success', llm_analysis: analysisText, cached: false })
+```
+
+- [ ] **Step 7: Re-export structural check from analysisLint for the thin path**
+
+`BrowserAIService.analyzeShot` (~147) already imports `lintShotAnalysis`/`repairShotAnalysis`
+from `@/lib/analysisLint`. Add `checkStructure` to that path so the secondary native route is also
+structure-aware. In `BrowserAIService.ts` line ~33:
+
+```typescript
+import { lintShotAnalysis, repairShotAnalysis, checkStructure } from '@/lib/analysisLint'
+```
+
+And update its validity check (~147):
+
+```typescript
+      const valid = (txt: string) => lintShotAnalysis(txt).valid && checkStructure(txt).valid
+      if (!valid(text)) {
+        const retry = await runAnalysis()
+        text = valid(retry.text)
+          ? retry.text
+          : repairShotAnalysis(retry.text.length >= text.length ? retry.text : text)
+      }
+```
+
+- [ ] **Step 8: Run regression both runtimes**
+
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py -k "Structure or Validator or llm or analyze" -q`
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/analysisLint.test.ts src/services/interceptor src/services/ai/BrowserAIService.test.ts`
+Expected: PASS (if `BrowserAIService.test.ts` does not exist, omit it)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/server/analysis_schema.py apps/server/services/analysis_validator.py apps/server/api/routes/shots.py apps/web/src/services/interceptor/DirectModeInterceptor.ts apps/web/src/services/ai/BrowserAIService.ts apps/server/test_main.py
+git commit -m "feat(analysis): universal structural lint wiring across all paths (L1/L2/L3)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 17: Release-gate coverage matrix + full verification (L5)
+
+A single test enumerates each runtime × check so the parity contract is explicit and a future
+regression (e.g. removing the validator from one path) fails loudly.
+
+**Files:**
+- Create: `apps/web/src/lib/analysisCoverage.test.ts`
+- Test (server): `apps/server/test_main.py` (`TestAnalysisCoverageMatrix`)
+
+- [ ] **Step 1: Write the native coverage test**
+
+Create `apps/web/src/lib/analysisCoverage.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import * as lint from './analysisLint'
+
+describe('analysis coverage matrix (L5, native)', () => {
+  it('exposes degeneracy, structural, and fact-aware checks', () => {
+    expect(typeof lint.lintShotAnalysis).toBe('function')
+    expect(typeof lint.checkStructure).toBe('function')
+    expect(typeof lint.validateAgainstFacts).toBe('function')
+    expect(typeof lint.repairShotAnalysis).toBe('function')
+  })
+})
+```
+
+- [ ] **Step 2: Write the server coverage test**
+
+Append to `apps/server/test_main.py`:
+
+```python
+class TestAnalysisCoverageMatrix:
+    def test_server_exposes_all_analysis_checks(self):
+        from services import analysis_validator as v
+        assert callable(v.validate_against_facts)
+        assert callable(v.check_structure)
+        from analysis_knowledge import build_fact_sheet, ANALYSIS_KNOWLEDGE  # noqa: F401
+        from services.shot_facts import build_shot_facts, classify_trigger  # noqa: F401
+        from services.compass_rules import compass_adjustments  # noqa: F401
+```
+
+- [ ] **Step 3: Run both coverage tests**
+
+Run: `cd apps/web && bun run test:run -- --reporter=dot src/lib/analysisCoverage.test.ts`
+Run: `cd apps/server && TEST_MODE=true .venv/bin/python -m pytest test_main.py::TestAnalysisCoverageMatrix -q`
+Expected: PASS
+
+- [ ] **Step 4: Full verification (both runtimes)**
+
+Run:
+```bash
+cd apps/web && bun run test:run -- --reporter=dot
+npx tsc --noEmit 2>&1 | grep -v "useGenerationProgress.ts:94\|test/setup.ts:57" | grep "error TS" || echo "tsc baseline OK"
+bun run build
+bunx eslint . 2>&1 | tail -5
+```
+Then:
+```bash
+cd ../server && TEST_MODE=true .venv/bin/python -m pytest -q
+.venv/bin/ruff check . && .venv/bin/black --check services/shot_facts.py services/compass_rules.py services/analysis_validator.py analysis_knowledge.py analysis_schema.py api/routes/shots.py
+```
+Expected: web suite green, tsc baseline only (2), build OK, eslint 0 errors; server suite green, ruff + black clean on the new/modified files.
+
+- [ ] **Step 5: i18n parity check**
+
+Run the repo's locale-parity test (the one that asserts equal key counts across locales — search
+`featureParity.test.ts` or an i18n test):
+```bash
+cd apps/web && bun run test:run -- --reporter=dot src/lib/featureParity.test.ts
+```
+Expected: PASS (all 6 locales have the new `analysis.*` keys).
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add apps/web/src/lib/analysisCoverage.test.ts apps/server/test_main.py
+git commit -m "test(analysis): add release-gate coverage matrix for both runtimes (L5)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+**Phase 4 complete.** All analysis paths run degeneracy + structural + fact-aware validation from
+a single-source schema, with an explicit coverage matrix guarding parity.
+
+---
+
+## Done-When
+
+- D1–D6 deterministic ShotFacts exist in both runtimes with identical thresholds and table-driven
+  #423 classification tests.
+- The static analysis view shows Targeted/Failsafe badges, stall/channeling flags, curve deltas,
+  and (when taste supplied) deterministic compass adjustments.
+- Both AI prompts carry ANALYSIS_KNOWLEDGE, the digested fact sheet (replacing raw JSON), a
+  few-shot example, and compass taste parity.
+- Every analysis path (server route, native DirectMode, native BrowserAIService) runs degeneracy +
+  structural + fact-aware validation with retry/repair, from a single-source section schema.
+- The compass is an optional, skippable pre-analysis step; taste persists per shot and feeds both
+  the AI and deterministic rules.
+- Full web + server suites green; tsc baseline (2) unchanged; lint 0 errors; build OK; ruff/black
+  clean on touched files; 6-locale i18n parity intact.

--- a/docs/superpowers/specs/2026-06-30-ai-analysis-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-30-ai-analysis-overhaul-design.md
@@ -149,7 +149,8 @@ channeling flags, the phase breakdown, and curve-adherence deltas. New i18n keys
 - **K3 — Few-shot worked example.** One compact example shot → ideal analysis embedded in the
   prompt to lock format and reasoning depth. Single example to bound token cost.
 - **K4 — Semantic validation + repair (both runtimes).** Extend `analysisLint.ts` and add a
-  server parity validator sharing one schema. Checks: all required sections/subsections
+  server parity validator sharing one schema (the linter's format coverage and test matrix are
+  formalized in Phase 4). Checks: all required sections/subsections
   present; `Assessment` is one of the allowed enum values; `RECOMMENDATIONS_JSON` parses and
   values stay within profile variable bounds; and **anti-hallucination cross-checks** — reject
   or repair claims that contradict `ShotFacts` (e.g. AI claims "reached target yield" when D1
@@ -173,6 +174,34 @@ channeling flags, the phase breakdown, and curve-adherence deltas. New i18n keys
 
 ---
 
+## Phase 4 — Linter format coverage & comprehensive test coverage
+
+The recently introduced AI-analysis linter (`analysisLint.ts`, degeneracy-only) must be
+expanded to fully cover the **new** output format produced by Phases 1–3, and validation must
+be wired across every analysis entry point in both runtimes. K4 introduces the semantic
+validator; Phase 4 makes the linter a first-class, explicitly-tested deliverable and closes
+any gaps so the linter cannot drift out of sync with the output schema.
+
+- **L1 — Format-aware linting.** Extend the linter (and its server parity validator) to assert
+  the full new section schema: required headers/subsections, the `Assessment` enum, the
+  bullet-point structure, the `RECOMMENDATIONS_JSON` block (parse + bounds), and the
+  Taste-Based Recommendations section when compass data is present. Keep the existing
+  degeneracy checks (repetition/diversity/empty).
+- **L2 — Single source of truth for the schema.** The expected-section schema lives in one
+  shared definition per runtime, consumed by both the prompt builder and the linter, so the
+  prompt and the validator cannot diverge. Numerically/structurally identical across runtimes.
+- **L3 — Universal wiring.** Every analysis path runs the linter → retry → repair → fallback,
+  including native DirectMode (currently returns raw, unlinted text) and the server LLM route.
+  No entry point may return unvalidated analysis text.
+- **L4 — Anti-hallucination tie-in.** The linter consumes `ShotFacts` so contradiction checks
+  (D1 Failsafe vs an AI "yield reached" claim) are part of the standard lint pass, not a
+  separate ad-hoc step.
+- **L5 — Comprehensive test coverage (release gate).** A coverage matrix proving the linter
+  catches and repairs each failure mode, on **both** runtimes (see Testing). New code lands
+  with tests for success **and** failure/edge-case paths, per project conventions.
+
+---
+
 ## Testing (dual-runtime, parity is release-blocking)
 
 - Table-driven unit tests for every D1 trigger combination → expected classification, including
@@ -182,8 +211,18 @@ channeling flags, the phase breakdown, and curve-adherence deltas. New i18n keys
 - D6 compass rule tests: each quadrant + descriptors → expected adjustments.
 - K4 validator tests: schema gaps, out-of-bounds recommendations, and anti-hallucination
   (fact says Failsafe → AI claim of "yield reached" is rejected/repaired).
+- **Phase 4 linter coverage matrix (release gate), both runtimes:** for each failure mode —
+  missing/extra section, invalid `Assessment` value, malformed/missing bullet structure,
+  unparseable or out-of-bounds `RECOMMENDATIONS_JSON`, missing Taste-Based Recommendations
+  when compass data is present, runaway repetition/low-diversity, and a fact contradiction —
+  assert the linter (a) flags it and (b) repair or retry yields valid output. Plus a
+  schema-drift guard test asserting the prompt builder and linter consume the same shared
+  schema definition (L2).
 - Golden small-model regression: feed a known-bad shot, assert the output passes the new
   validator (and that repair fires when needed).
+- Each new function (`buildShotFacts`/`build_shot_facts`, `compassAdjustments`,
+  `buildFactSheet`, validator) ships with success **and** failure/edge-case tests per project
+  conventions; no analysis entry point returns unvalidated text (L3).
 - i18n parity: all new keys present in all 6 locales (existing parity test covers this).
 - Server suite in `test_main.py` / `test_ai_providers.py`; web suite via
   `bun run test:run -- --reporter=dot <paths>`.

--- a/docs/superpowers/specs/2026-06-30-ai-analysis-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-30-ai-analysis-overhaul-design.md
@@ -1,0 +1,204 @@
+# AI Shot Analysis Overhaul — Design
+
+**Date:** 2026-06-30
+**Issue:** #423 (Profile Logic: Targets vs. Limits vs. Exit Triggers) + AI analysis quality overhaul
+**Branch context:** created from the active milestone branch (not `main`)
+**Status:** Approved design — ready for implementation planning
+
+## Problem
+
+AI shot analysis performs acceptably on large models but is **intermittently spotty and
+often wrong on smaller models** (e.g. Apple Intelligence, Gemma, smaller hosted models).
+Root causes identified during exploration:
+
+1. **Raw-JSON reasoning burden.** Both runtimes hand the model a verbose
+   `JSON.stringify(local_analysis)` + profile-stages JSON + raw graph samples and ask it to
+   derive *all* interpretation (channeling, stall, extraction quality). Small models choke on
+   nested JSON and hallucinate.
+2. **No diagnostic knowledge base for analysis.** Profile generation injects a rich
+   `PROFILING_KNOWLEDGE` guide; shot analysis does not get an analysis-specific equivalent.
+   Worse, the profiling guide is injected **server-side only** — the native DirectMode prompt
+   omits it (a dual-runtime parity gap).
+3. **Validation only catches degeneracy, not correctness.** `analysisLint.ts` detects
+   repetition/low-diversity/empty output, but nothing checks that the analysis follows the
+   section schema, that recommendations parse and stay within bounds, or that claims do not
+   contradict the measured data. The native DirectMode path returns raw, unlinted text.
+4. **#423 unimplemented.** `_determine_exit_trigger_hit` detects *which* trigger fired but
+   never classifies a stage ending as **Targeted** vs **Failsafe**, so a stage that timed out
+   from stalling is presented as a success.
+5. **Espresso Compass underused.** A 2D taste pad (X sour↔bitter, Y weak↔strong, +
+   descriptors) already feeds the server AI, but: it is not offered as a step in the analysis
+   flow, the native DirectMode prompt omits its `taste_context`, and its domain knowledge is
+   never applied deterministically.
+
+## Goal
+
+Give the analysis **better tools** so quality is **consistent across model sizes**, by:
+moving interpretation into a deterministic fact layer (which also upgrades the non-AI static
+analysis), giving the AI a diagnostic knowledge base + digested facts + few-shot example +
+semantic validation, and integrating the Espresso Compass as an optional pre-analysis step
+that feeds both the AI and deterministic rules.
+
+## Anchoring decisions (from brainstorming)
+
+- **Philosophy:** Both — deterministic fact layer **and** upgraded AI prompting/validation.
+- **Compass flow:** Optional, skippable step **before** analysis; result feeds **both** the AI
+  and deterministic rule-based adjustments.
+- **Signal visibility:** Enrich the existing static/local-analysis view (`ShotDetail.tsx`)
+  with the new classifications/flags (moderate UI + 6-locale i18n).
+- **Scoping:** One spec, phased implementation.
+
+## Dual-runtime contract (release-blocking)
+
+Every behavior below MUST be implemented in **both** runtimes with tests on both sides:
+
+- **Server mode:** Python FastAPI — `apps/server/services/analysis_service.py`,
+  `apps/server/api/routes/shots.py`.
+- **Native/Capacitor mode:** TypeScript — `apps/web/src/lib/profileAnalysis.ts`,
+  `apps/web/src/services/interceptor/DirectModeInterceptor.ts`,
+  `apps/web/src/services/ai/` (prompts, providers), `apps/web/src/lib/analysisLint.ts`.
+
+Mismatched behavior between runtimes is a release-blocking bug.
+
+---
+
+## Architecture
+
+Introduce a single deterministic fact layer per runtime that both the static view and the AI
+consume. Pure, independently testable functions.
+
+```
+telemetry + profile ──▶ buildShotFacts() ──▶ ShotFacts (typed)
+                                              │
+                          ┌───────────────────┼───────────────────┐
+                          ▼                   ▼                   ▼
+                  static view render    buildFactSheet()    (unchanged raw
+                  (ShotDetail.tsx)      → prose for prompt   JSON, optional/
+                  D1–D6 badges/flags    (K2)                 large-model only)
+
+taste (X,Y,descriptors) ─▶ compassAdjustments() ─▶ deterministic recs (D6)
+                                                  └─▶ taste_context for AI (K5)
+
+AI output ─▶ validateAnalysis() (K4) ─▶ retry → repair → fallback
+            (schema + bounds + anti-hallucination vs ShotFacts)
+```
+
+New/changed units:
+
+- **`ShotFacts` builder** — `apps/server/services/analysis_service.py` (`build_shot_facts()`)
+  and TS `apps/web/src/lib/shotFacts.ts`. Input: telemetry + profile + existing local
+  analysis. Output: typed `ShotFacts` (D1–D5). No I/O, no LLM.
+- **Compass rules** — pure `compassAdjustments(tasteX, tasteY, descriptors)` in each runtime
+  (D6). Returns a list of `{ axis, direction, adjustments[] }`.
+- **Knowledge base** — `ANALYSIS_KNOWLEDGE` constant mirrored per runtime, sibling to
+  `PROFILING_KNOWLEDGE` (K1).
+- **Fact sheet builder** — `buildFactSheet(facts)` → compact labeled prose for the prompt (K2).
+- **Validator** — extend `analysisLint.ts` + new server parity validator sharing one schema
+  definition (K4).
+
+---
+
+## Phase 1 — Deterministic fact layer + static view (#423)
+
+Computed once in `buildShotFacts()`; rendered in the static view and fed to the AI.
+
+- **D1 — Trigger classification (#423).** For each stage ending, classify **Targeted** vs
+  **Failsafe** using control-mode + trigger-type + trigger-count:
+  - weight trigger → `Targeted (yield reached)`
+  - time trigger, only trigger on stage → `Targeted (planned duration)`;
+    time trigger with other triggers present → `Failsafe (timeout — likely stalled)`
+  - flow-control stage + pressure trigger → `Targeted (puck resistance achieved)`
+  - pressure-control stage + flow trigger → only trigger `Targeted (planned flow transition)`,
+    else `Failsafe (channeling/choking caught)`
+  - pressure-control stage + pressure trigger → `Targeted (threshold reached)`
+  - fallback → `Unknown`
+  Resolves the #423 "stalled-but-shown-as-success" ambiguity.
+- **D2 — Stall detection.** Flag a stage as stalled when it exits on a time **Failsafe** AND
+  the weight gain in its final window is below a threshold (intended yield not reached).
+  Distinguishes a planned timed rest from a flow-death timeout.
+- **D3 — Channeling indicators.** Deterministic flags from telemetry: pressure-drop-with-
+  flow-rise, flow before adequate pressure build, and flow variance beyond a stable band.
+  Replaces asking the model to guess channeling with no computed signal.
+- **D4 — Extraction-phase breakdown.** Segment the shot into pre-infusion / ramp / peak /
+  decline phases from the measured curve (independent of profile stage names), with per-phase
+  pressure/flow/weight summaries.
+- **D5 — Target-curve adherence.** Diff measured pressure/flow against the profile's target
+  dynamics points per stage → deviation deltas (e.g. "ran 1.1 bar under target in stage 2").
+- **D6 — Compass deterministic rules.** `compassAdjustments()` maps taste to rule-based
+  recommendations (sour→under-extraction fixes, bitter→over, weak/strong→ratio), shown
+  alongside the AI output, model-independent.
+
+**Static-view impact:** `ShotDetail.tsx` gains Targeted/Failsafe badges per stage, stall &
+channeling flags, the phase breakdown, and curve-adherence deltas. New i18n keys across all
+6 locales (`en`, `sv`, `de`, `es`, `fr`, `it`).
+
+---
+
+## Phase 2 — AI analysis layer
+
+- **K1 — `ANALYSIS_KNOWLEDGE`.** New diagnostic knowledge block (sibling to
+  `PROFILING_KNOWLEDGE`): under/over-extraction curve signatures, reading Targeted vs Failsafe
+  endings, channeling signatures, ratio/yield reasoning, and the compass mapping. Injected in
+  **both** runtimes (also closes the existing server-only profiling-knowledge parity gap for
+  analysis).
+- **K2 — Digested fact sheet.** Replace the raw `JSON.stringify(local_analysis)` +
+  graph-sample dump with `buildFactSheet(facts)` — compact labeled prose derived from D1–D5
+  (e.g. "Stage 2 'Infusion': ended on TIME as a FAILSAFE — stalled, +3g in last 4s; 1.1 bar
+  under target; channeling: none"). Raw JSON retained only optionally for large models / behind
+  a flag.
+- **K3 — Few-shot worked example.** One compact example shot → ideal analysis embedded in the
+  prompt to lock format and reasoning depth. Single example to bound token cost.
+- **K4 — Semantic validation + repair (both runtimes).** Extend `analysisLint.ts` and add a
+  server parity validator sharing one schema. Checks: all required sections/subsections
+  present; `Assessment` is one of the allowed enum values; `RECOMMENDATIONS_JSON` parses and
+  values stay within profile variable bounds; and **anti-hallucination cross-checks** — reject
+  or repair claims that contradict `ShotFacts` (e.g. AI claims "reached target yield" when D1
+  says Failsafe stall). On failure: one retry → repair → graceful fallback. Wire into
+  DirectMode, which currently returns raw, unlinted text.
+- **K5 — Compass context parity.** Inject the compass `taste_context` in native DirectMode
+  (the server already does) so taste feedback reaches the model in both runtimes.
+
+---
+
+## Phase 3 — Compass UX
+
+- **U1 — Optional pre-analysis step.** Before running AI shot analysis, present an optional
+  "How did it taste?" step reusing the existing 2D taste pad + descriptors. Skippable in one
+  tap; skipping runs analysis without taste. Server + native parity.
+- **U2 — Dual feed.** On submit, taste feeds both the AI (K5) and the deterministic compass
+  rules (D6). The static view shows the rule-based adjustment; the AI weaves it into its
+  recommendations.
+- **U3 — Persist taste with shot.** Store the taste input with the shot so re-analysis / cache
+  reuse does not re-ask.
+
+---
+
+## Testing (dual-runtime, parity is release-blocking)
+
+- Table-driven unit tests for every D1 trigger combination → expected classification, including
+  the #423 worked examples, on **both** runtimes.
+- D2/D3/D4/D5 unit tests with synthetic telemetry fixtures (stalled stage, channeling spike,
+  clean shot, under-target curve).
+- D6 compass rule tests: each quadrant + descriptors → expected adjustments.
+- K4 validator tests: schema gaps, out-of-bounds recommendations, and anti-hallucination
+  (fact says Failsafe → AI claim of "yield reached" is rejected/repaired).
+- Golden small-model regression: feed a known-bad shot, assert the output passes the new
+  validator (and that repair fires when needed).
+- i18n parity: all new keys present in all 6 locales (existing parity test covers this).
+- Server suite in `test_main.py` / `test_ai_providers.py`; web suite via
+  `bun run test:run -- --reporter=dot <paths>`.
+
+## Out of scope
+
+- New cloud provider image generation (tracked separately).
+- Re-architecting profile generation (only its knowledge-base pattern is mirrored, not changed).
+- Unrelated refactors of the static analysis beyond what D1–D6 require.
+
+## Open implementation notes
+
+- `buildShotFacts()` should reuse existing helpers (`_extract_shot_stage_data`,
+  `_compute_stage_stats`, `_determine_exit_trigger_hit`) rather than re-deriving telemetry
+  grouping; D1 wraps/extends `_determine_exit_trigger_hit` with the classification layer.
+- Keep `ShotFacts` serializable so it can be cached with the shot alongside the taste input.
+- Thresholds (stall window, channeling variance band, curve-adherence tolerance) defined as
+  named constants in one place per runtime, kept numerically identical across runtimes.


### PR DESCRIPTION
## Summary

Overhauls AI shot analysis (#423) so quality is **consistent across model sizes** by giving the AI deterministic, digested facts to reason over instead of raw telemetry. Implemented with full **dual-runtime parity** (Python server + native/Capacitor TS) and an explicit release-gate coverage matrix.

Closes #423.

## What changed (4 phases, 17 tasks)

**Phase 1 — Deterministic fact layer (both runtimes)**
- `shot_facts.py` ↔ `shotFacts.ts`: #423 Targeted/Failsafe trigger classification, stall + channeling detectors, phase derivation, curve-adherence scaffold. Identical thresholds (stall 0.5 g, channeling 1.5 bar / 1.5 ml·s⁻¹).
- `compass_rules.py` ↔ `compassRules.ts`: deterministic taste→dial-in adjustments (DEADBAND 0.25).
- Static view enriched with Targeted/Failsafe badges, stall/channeling flags (`ShotFactsPanel.tsx`).

**Phase 2 — Upgraded AI layer (both runtimes)**
- `analysis_knowledge.py` ↔ `analysisKnowledge.ts`: shared `ANALYSIS_KNOWLEDGE` framework, digested **fact sheet** (replaces the raw-JSON dump in the prompt), and a few-shot example.
- Anti-hallucination validators: `analysis_validator.py` ↔ `analysisLint.ts` (`validate_against_facts`/`validateAgainstFacts`) — flag mischaracterized Targeted exits and unsupported channeling claims; warn→one-retry, never hard-block.
- Native `/analyze-llm` now reuses the **rich** local analysis (extracted `computeRichLocalAnalysis`) so its fact sheet is fully populated, matching the server.

**Phase 3 — Espresso Compass UX**
- Optional, skippable `AnalysisTasteGate` before AI analysis; taste persists per shot (`shotTasteStore`) and dual-feeds both the AI prompt (taste context) and deterministic compass adjustments in the UI.

**Phase 4 — Format-aware linting**
- Single-source section schema `analysis_schema.py` ↔ `analysisSchema.ts` + structural lint (`check_structure`/`checkStructure`), wired into **every** analysis output path (server route, native DirectMode, native BrowserAIService).
- Release-gate coverage matrix test in both runtimes.

## Verification
- Web: **1306 passed / 2 skipped**; tsc baseline unchanged (2 known); `bun run build` OK; eslint 0 errors.
- Server: **1053 passed / 3 skipped** (20 pre-existing live-machine integration-fixture errors, untouched by this branch); ruff clean; black clean on touched files.
- i18n: all 6 locales (en/sv/de/es/fr/it) at parity, including new `analysis.*` keys.
- Independent code review: no Critical / no Important findings; cross-runtime parity verified.

## Curve adherence (now implemented)
- `curve_adherence` fires in **both** runtimes: the numeric per-stage target is the mean of resolved pressure/flow `dynamics` setpoints (`_mean_dynamics_target` / `meanDynamicsTarget`), and delta = measured − target. Returns null only for non-pressure/flow stages or when no numeric setpoints exist (safe degradation preserved).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
