### PR TITLE
fix(ios): guard eager Apple Intelligence init from crashing on Mac

### DIFF
--- a/apps/web/scripts/patch-capacitor-spm.sh
+++ b/apps/web/scripts/patch-capacitor-spm.sh
@@ -272,6 +272,54 @@ for PLUGIN_DIR in "$NODE_MODULES"/@aparajita/*/ios; do
     done
 done
 
+# ─── capgo/capacitor-llm: guard eager Apple Intelligence init on Mac ─
+# LLMPlugin's `appleModel` is a stored-property initializer, so Capacitor
+# runs it unconditionally at bridge startup for every plugin instance —
+# before any JS/runtime gating in localLLM.ts ever executes. The plugin
+# only special-cases Mac Catalyst (targetEnvironment(macCatalyst)); it has
+# no guard for an iOS/iPadOS binary running "Designed for iPad" on Apple
+# Silicon Mac, where FoundationModels' SystemLanguageModel.default is not
+# functional and crashes the app before it can boot. Skip eagerly touching
+# it in that environment (mirrors the plugin's own isiOSAppOnMac check
+# elsewhere in Capacitor apps); everything downstream already treats a nil
+# appleModel as "unavailable" rather than crashing.
+LLM_PLUGIN="$NODE_MODULES/@capgo/capacitor-llm/ios/Sources/LLMPlugin/LLMPlugin.swift"
+if [ -f "$LLM_PLUGIN" ] && ! grep -q 'isiOSAppOnMac' "$LLM_PLUGIN" 2>/dev/null; then
+    python3 << PYEOF
+path = "$LLM_PLUGIN"
+with open(path, 'r') as f:
+    content = f.read()
+
+original = content
+content = content.replace(
+    '''    private var appleModel: Any? = {
+        if #available(iOS 26.0, *) {
+            return SystemLanguageModel.default
+        } else {
+            return nil
+        }
+    }()''',
+    '''    private var appleModel: Any? = {
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            return nil
+        }
+        if #available(iOS 26.0, *) {
+            return SystemLanguageModel.default
+        } else {
+            return nil
+        }
+    }()'''
+)
+
+if content != original:
+    with open(path, 'w') as f:
+        f.write(content)
+    print("  Patched: @capgo/capacitor-llm (guarded eager Apple Intelligence init on Mac)")
+else:
+    print("  No changes: @capgo/capacitor-llm (expected pattern not found — plugin source may have changed)")
+PYEOF
+fi
+
 # ─── capacitor-zeroconf special handling ────────────────────────────
 # Needs Package.swift for SPM + CAPBridgedPlugin conformance
 ZEROCONF_DIR="$NODE_MODULES/capacitor-zeroconf"


### PR DESCRIPTION
## Summary
- 2.6.0 added on-device AI via `@capgo/capacitor-llm` (#373). That plugin's `LLMPlugin.swift` eagerly initializes `SystemLanguageModel.default` (Apple Intelligence) in a stored-property initializer, which Capacitor runs for every registered plugin at bridge startup — before any of our own JS-level platform gating in `localLLM.ts` ever runs.
- The plugin only guards against Mac Catalyst (`targetEnvironment(macCatalyst)`). It has no guard for an iOS/iPadOS binary running "Designed for iPad" on an Apple Silicon Mac, where `SystemLanguageModel.default` isn't functional and crashes the app before it can boot.
- This is the cause of the regression between TestFlight 2.6.0 build (2) and (3) reported as "app doesn't boot on M1 Mac" — build (3) is the first build to include the on-device AI feature.
- Extends the existing `apps/web/scripts/patch-capacitor-spm.sh` postinstall patcher (already used for other native plugin fixes in this project) to guard the eager initializer behind `ProcessInfo.processInfo.isiOSAppOnMac`, matching the plugin's own Catalyst-gating precedent. Downstream code already treats a `nil` `appleModel` as "unavailable" gracefully, so no other behavior changes.
- This is a stopgap patch until the fix lands upstream in `@capgo/capacitor-llm` itself (will file a PR there too).

## Test plan
- [x] `bun install` in `apps/web` runs the postinstall hook and confirms the patch applies to `node_modules/@capgo/capacitor-llm/ios/Sources/LLMPlugin/LLMPlugin.swift`
- [x] Re-running the patch script is a no-op (idempotent)
- [x] `xcodebuild` for `generic/platform=iOS Simulator` succeeds with the patched plugin compiled in
- [ ] Manually verify boot succeeds on an Apple Silicon Mac via TestFlight/Xcode Organizer archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)