### PR TITLE
fix(ai): compact on-device prompts to fit Apple Intelligence context window

### DIFF
--- a/apps/web/src/services/ai/BrowserAIService.ts
+++ b/apps/web/src/services/ai/BrowserAIService.ts
@@ -33,7 +33,7 @@ import { STORAGE_KEYS } from '@/lib/constants'
 import { lintShotAnalysis, repairShotAnalysis, checkStructure } from '@/lib/analysisLint'
 import { safeRandomUUID } from '@/lib/uuid'
 import { AIServiceError, type AIErrorCode as AIErrorCodeBase } from './aiErrors'
-import { getProviderForMethod, isAIConfigured } from './providers'
+import { getProviderForMethod, isAIConfigured, needsCompactPrompt } from './providers'
 
 /**
  * Typed AI service error codes — UI layer translates these via i18n.
@@ -84,6 +84,7 @@ export function createBrowserAIService(): AIService {
         request.preferences,
         request.tags,
         !!request.image,
+        needsCompactPrompt(provider),
       )
       parts.push({ text: systemPrompt })
 

--- a/apps/web/src/services/ai/profilePromptFull.compact.test.ts
+++ b/apps/web/src/services/ai/profilePromptFull.compact.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { buildFullProfilePrompt, buildCompactProfilePrompt } from './profilePromptFull'
+
+describe('buildFullProfilePrompt (compact / on-device)', () => {
+  const args = ['Metic', 'light roast, 1:3 ratio', ['turbo'], false] as const
+
+  it('is materially smaller than the full prompt', () => {
+    const full = buildFullProfilePrompt(...args)
+    const compact = buildFullProfilePrompt(...args, true)
+    expect(compact.length).toBeLessThan(full.length * 0.6)
+  })
+
+  it('delegates to the compact builder when compact=true', () => {
+    const viaFlag = buildFullProfilePrompt(...args, true)
+    const direct = buildCompactProfilePrompt(...args)
+    expect(viaFlag).toBe(direct)
+  })
+
+  it('preserves the output contract the extractor needs', () => {
+    const p = buildFullProfilePrompt(...args, true)
+    expect(p).toContain('**Profile Created:**')
+    expect(p).toContain('```json')
+    expect(p).toContain('author')
+  })
+
+  it('keeps the rejection-critical validation rules', () => {
+    const p = buildFullProfilePrompt(...args, true)
+    // paradox rule, failsafe/time backup, cross-type limits, relative time
+    expect(p).toMatch(/flow stage must NOT have a flow exit trigger/i)
+    expect(p).toMatch(/time exit trigger/i)
+    expect(p).toMatch(/pressure stages need a flow limit/i)
+    expect(p).toMatch(/relative/i)
+  })
+
+  it('honours mandatory user preferences', () => {
+    const p = buildFullProfilePrompt('Metic', '20g dose', [], false, true)
+    expect(p).toContain('20g dose')
+    expect(p).toMatch(/MANDATORY/i)
+  })
+
+  it('adapts the task line for image input', () => {
+    const withImage = buildFullProfilePrompt('Metic', '', [], true, true)
+    const noImage = buildFullProfilePrompt('Metic', '', [], false, true)
+    expect(withImage).toMatch(/coffee bag image/i)
+    expect(noImage).not.toMatch(/coffee bag image/i)
+  })
+})

--- a/apps/web/src/services/ai/profilePromptFull.ts
+++ b/apps/web/src/services/ai/profilePromptFull.ts
@@ -166,6 +166,55 @@ Profile JSON structure: {name, author, stages[], variables[], temperature}
 
 `
 
+const COMPACT_PROFILE_PROMPT = `You are a creative, expert espresso barista designing a profile for a Meticulous Espresso Machine. Use witty, pun-heavy but clear naming; never reuse generic names.
+
+REQUIREMENTS:
+- User preferences are MANDATORY: if the user gives a dose, grind, temperature, ratio, etc., use EXACTLY that value; only use defaults (18 g dose, 93°C) when unspecified.
+- Keep to 3-4 stages (6 max). Typical phases: pre-infusion, optional bloom, infusion (ramp to 6-9 bar or 1.5-3 ml/s), taper.
+
+VARIABLES (required 'variables' array):
+- First entry is dose: {"name":"☕ Dose","key":"info_dose","type":"weight","value":18}. INFO variable names (key starts 'info_') MUST start with an emoji; adjustable variable names must NOT start with an emoji and must be referenced in a stage via $key.
+
+VALIDATION (profile is rejected if violated):
+- A flow stage must NOT have a flow exit trigger; a pressure stage must NOT have a pressure exit trigger.
+- Every stage needs a time exit trigger OR multiple exit triggers (time failsafe backup).
+- Flow stages need a pressure limit; pressure stages need a flow limit; a limit's type must differ from the stage type.
+- Time exit triggers and all dynamics x-axis values are ALWAYS relative to stage start ("relative": true).
+- interpolation: 'linear' or 'curve' only. dynamics.over: 'time' | 'weight' | 'piston_position'. Stage types: 'power' | 'flow' | 'pressure'. Exit trigger types: 'weight' | 'pressure' | 'flow' | 'time' | 'piston_position' | 'power' | 'user_interaction'; comparison '>=' or '<='. Pressure max 15 bar. Do NOT add a weight exit trigger to the final stage (the machine handles the global weight target).
+
+OEPF JSON: {name, author, temperature (°C number), stages[], variables[]}. Each stage: {name, type, dynamics:{points:[[x,y],...], over, interpolation}, limits:[{type,value}], exit_triggers:[{type,value,comparison,relative?}], exit_type?:'or'|'and'}. Reference variables as {"points":[[0,"$peak_pressure"]]}.
+
+`
+
+/** Compact profile prompt for on-device models with a ~4096-token window. */
+export function buildCompactProfilePrompt(
+  authorName: string,
+  preferences: string,
+  tags: string[],
+  hasImage: boolean,
+): string {
+  const allPrefs = [preferences, ...tags].filter(Boolean).join(', ')
+  const task = hasImage
+    ? 'Analyze the coffee bag image and create a sophisticated espresso profile for it.'
+    : 'Create a sophisticated espresso profile.'
+  const prefsSection = allPrefs
+    ? `⚠️ MANDATORY USER REQUIREMENTS (follow EXACTLY): '${allPrefs}'\n\n`
+    : ''
+  return (
+    COMPACT_PROFILE_PROMPT +
+    `AUTHOR: set the profile 'author' field to "${authorName}".\n\n` +
+    prefsSection +
+    `TASK: ${task}\n\n` +
+    `OUTPUT (use this exact format):\n` +
+    `**Profile Created:** [Name]\n\n` +
+    `**Description:** [1-2 sentences]\n\n` +
+    `**Preparation:** dose, grind, temperature, and any other prep steps\n\n` +
+    `**Why This Works:** [reasoning]\n\n` +
+    `**Special Notes:** [requirements, or 'None']\n\n` +
+    `Then the complete profile as a fenced \`\`\`json block (include a 'display' object with a markdown 'description' field). Do NOT call tools.\n`
+  )
+}
+
 export const PROFILING_KNOWLEDGE = `ESPRESSO PROFILING GUIDE:
 
 ## Core Concepts
@@ -237,7 +286,10 @@ export function buildFullProfilePrompt(
   preferences: string,
   tags: string[],
   hasImage: boolean,
+  compact = false,
 ): string {
+  if (compact) return buildCompactProfilePrompt(authorName, preferences, tags, hasImage)
+
   const authorSection = `AUTHOR:\n• Set the 'author' field in the profile JSON to: "${authorName}"\n\n`
 
   const allPrefs = [preferences, ...tags].filter(Boolean).join(', ')

--- a/apps/web/src/services/ai/providers/AIProvider.ts
+++ b/apps/web/src/services/ai/providers/AIProvider.ts
@@ -3,6 +3,14 @@ export interface ProviderCapabilities {
   vision: boolean
   imageGen: boolean
   jsonMode: boolean
+  /**
+   * Approximate total context window (input + output) in tokens, when the
+   * provider has a hard limit small enough that full prompts overflow it.
+   * On-device models (Apple Intelligence, Gemma) sit around 4096 tokens, so
+   * the large analysis/profile prompts must be compacted for them. Hosted
+   * providers leave this undefined (effectively unbounded for our prompts).
+   */
+  contextWindowTokens?: number
 }
 
 export interface AIProvider {

--- a/apps/web/src/services/ai/providers/LocalLLMProvider.test.ts
+++ b/apps/web/src/services/ai/providers/LocalLLMProvider.test.ts
@@ -300,9 +300,16 @@ describe('contentsToPrompt', () => {
 describe('LocalLLMProvider', () => {
   it('is text-only with no image generation', () => {
     const p: AIProvider = new LocalLLMProvider()
-    expect(p.capabilities).toEqual({ text: true, vision: false, imageGen: false, jsonMode: false })
+    expect(p.capabilities).toEqual({
+      text: true, vision: false, imageGen: false, jsonMode: false, contextWindowTokens: 4096,
+    })
     expect(p.generateImage).toBeUndefined()
     expect(p.detectFromKey('whatever')).toBe(false)
+  })
+
+  it('advertises a small context window so call sites request compact prompts', () => {
+    const p: AIProvider = new LocalLLMProvider()
+    expect(p.capabilities.contextWindowTokens).toBeLessThanOrEqual(4096)
   })
   it('generates text through the on-device bridge', async () => {
     const p = new LocalLLMProvider()

--- a/apps/web/src/services/ai/providers/LocalLLMProvider.ts
+++ b/apps/web/src/services/ai/providers/LocalLLMProvider.ts
@@ -64,6 +64,10 @@ export class LocalLLMProvider implements AIProvider {
     vision: false,
     imageGen: false,
     jsonMode: false,
+    // Apple Intelligence and Gemma 4 E2B both run in a ~4096-token window
+    // (shared input + output). The full analysis/profile prompts overflow it,
+    // so call sites request a compacted prompt for this provider.
+    contextWindowTokens: 4096,
   }
 
   isConfigured(): boolean {

--- a/apps/web/src/services/ai/providers/index.ts
+++ b/apps/web/src/services/ai/providers/index.ts
@@ -36,6 +36,23 @@ export function getProviderForMethod(
   return getProvider(resolveProviderIdForMethod(method, opts))
 }
 
+/**
+ * Providers whose context window is at or below this many tokens cannot fit the
+ * full analysis/profile prompts and must be given a compacted variant.
+ */
+export const COMPACT_PROMPT_CONTEXT_THRESHOLD = 8192
+
+/**
+ * Whether the given provider needs the compact (small-context) prompt variant.
+ * On-device models (Apple Intelligence, Gemma) advertise a ~4096-token window;
+ * the full prompts overflow it and the model errors out ("exceeded model
+ * context window size") instead of returning a result.
+ */
+export function needsCompactPrompt(provider: AIProvider): boolean {
+  const window = provider.capabilities.contextWindowTokens
+  return window != null && window <= COMPACT_PROMPT_CONTEXT_THRESHOLD
+}
+
 export { geminiProvider, GeminiProvider } from './GeminiProvider'
 export { localLLMProvider, LocalLLMProvider } from './LocalLLMProvider'
 export { OpenAICompatProvider } from './OpenAICompatProvider'

--- a/apps/web/src/services/ai/providers/needsCompactPrompt.test.ts
+++ b/apps/web/src/services/ai/providers/needsCompactPrompt.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  needsCompactPrompt,
+  COMPACT_PROMPT_CONTEXT_THRESHOLD,
+  getProvider,
+} from './index'
+import type { AIProvider } from './AIProvider'
+
+function fakeProvider(contextWindowTokens?: number): AIProvider {
+  return {
+    id: 'fake',
+    label: 'Fake',
+    capabilities: { text: true, vision: false, imageGen: false, jsonMode: false, contextWindowTokens },
+    isConfigured: () => true,
+    detectFromKey: () => false,
+    generateText: async () => ({ text: '' }),
+    listModels: async () => [],
+  }
+}
+
+describe('needsCompactPrompt', () => {
+  it('is true for a small-window (on-device) provider', () => {
+    expect(needsCompactPrompt(fakeProvider(4096))).toBe(true)
+    expect(needsCompactPrompt(fakeProvider(COMPACT_PROMPT_CONTEXT_THRESHOLD))).toBe(true)
+  })
+
+  it('is false when no window is advertised (hosted, effectively unbounded)', () => {
+    expect(needsCompactPrompt(fakeProvider(undefined))).toBe(false)
+  })
+
+  it('is false for a large-window provider', () => {
+    expect(needsCompactPrompt(fakeProvider(COMPACT_PROMPT_CONTEXT_THRESHOLD + 1))).toBe(false)
+    expect(needsCompactPrompt(fakeProvider(1_000_000))).toBe(false)
+  })
+
+  it('flags the on-device local provider and not the hosted Gemini provider', () => {
+    expect(needsCompactPrompt(getProvider('local'))).toBe(true)
+    expect(needsCompactPrompt(getProvider('gemini'))).toBe(false)
+  })
+})

--- a/apps/web/src/services/interceptor/DirectModeInterceptor.ts
+++ b/apps/web/src/services/interceptor/DirectModeInterceptor.ts
@@ -1,6 +1,6 @@
 import { STORAGE_KEYS } from '@/lib/constants'
 import { createBrowserAIService } from '@/services/ai/BrowserAIService'
-import { getActiveProviderId, getActiveHostedProviderId, getProvider, getProviderForMethod, getProviderModel, isAIConfigured, PROVIDERS } from '@/services/ai/providers'
+import { getActiveProviderId, getActiveHostedProviderId, getProvider, getProviderForMethod, getProviderModel, isAIConfigured, needsCompactPrompt, PROVIDERS } from '@/services/ai/providers'
 import { retryWithBackoff, formatGeminiError } from '@/services/ai/retryUtils'
 import { AIServiceError } from '@/services/ai/aiErrors'
 import { isNativePlatform, getDefaultMachineUrl } from '@/lib/machineMode'
@@ -3231,6 +3231,12 @@ export function installDirectModeInterceptor(): void {
             : ''
 
           const facts = buildShotFacts(richAnalysis as Parameters<typeof buildShotFacts>[0])
+
+          // 5. Call the AI provider for shot analysis (with retry on transient errors)
+          if (!isAIConfigured()) {
+            return jsonResponse({ status: 'error', message: aiNotConfiguredMessage() })
+          }
+          const analyzeProvider = getProviderForMethod('analyzeShot')
           const prompt = buildAnalyzeLlmPrompt({
             profileName: pName,
             temperature: shotProfile?.temperature ?? null,
@@ -3240,13 +3246,9 @@ export function installDirectModeInterceptor(): void {
             cleanStages,
             facts,
             tasteContext,
+            compact: needsCompactPrompt(analyzeProvider),
           })
 
-          // 5. Call the AI provider for shot analysis (with retry on transient errors)
-          if (!isAIConfigured()) {
-            return jsonResponse({ status: 'error', message: aiNotConfiguredMessage() })
-          }
-          const analyzeProvider = getProviderForMethod('analyzeShot')
           const gen = async () => {
             const r = await retryWithBackoff(() => analyzeProvider.generateText({
               contents: [{ role: 'user', parts: [{ text: prompt }] }],

--- a/apps/web/src/services/interceptor/analyzeLlmPrompt.test.ts
+++ b/apps/web/src/services/interceptor/analyzeLlmPrompt.test.ts
@@ -75,3 +75,70 @@ describe('buildAnalyzeLlmPrompt', () => {
     expect(p).toContain('Targeted')
   })
 })
+
+describe('buildAnalyzeLlmPrompt (compact / on-device)', () => {
+  const bigVars = Array.from({ length: 12 }, (_, i) => ({
+    name: `Variable ${i}`, key: `var_${i}`, type: 'pressure', value: i,
+  }))
+  const bigStages = Array.from({ length: 6 }, (_, i) => ({
+    name: `Stage ${i}`, type: 'pressure', key: `stage_${i}`,
+    dynamics_points: [[0, 9], [3, 6]], dynamics_over: 'time',
+    exit_triggers: [{ type: 'weight', value: 36, comparison: '>=' }],
+    limits: [{ type: 'flow', value: 5 }],
+  }))
+  const base = {
+    profileName: 'Test', temperature: 93, targetWeight: 36, profileDescription: 'desc',
+    profileVars: bigVars, cleanStages: bigStages, facts, tasteContext: '',
+  }
+
+  it('is materially smaller than the full prompt', () => {
+    const full = buildAnalyzeLlmPrompt(base)
+    const compact = buildAnalyzeLlmPrompt({ ...base, compact: true })
+    expect(compact.length).toBeLessThan(full.length * 0.6)
+  })
+
+  it('fits a ~4096-token window with headroom for output', () => {
+    // ~4 chars/token: keep the compacted input well under the window so the
+    // model has room to generate the full analysis without overflowing.
+    const compact = buildAnalyzeLlmPrompt({ ...base, compact: true })
+    expect(compact.length).toBeLessThan(12_000)
+  })
+
+  it('drops the heavy knowledge blocks and worked example', () => {
+    const p = buildAnalyzeLlmPrompt({ ...base, compact: true })
+    expect(p).not.toContain('ESPRESSO PROFILING GUIDE')
+    expect(p).not.toContain('Worked Example')
+    expect(p).not.toContain('EXIT TRIGGER CLASSIFICATION')
+  })
+
+  it('preserves the output contract the parser needs', () => {
+    const p = buildAnalyzeLlmPrompt({ ...base, compact: true })
+    expect(p).toContain('## 1. Shot Performance')
+    expect(p).toContain('## 2. Root Cause Analysis')
+    expect(p).toContain('## 3. Setup Recommendations')
+    expect(p).toContain('## 4. Profile Recommendations')
+    expect(p).toContain('## 5. Profile Design Observations')
+    expect(p).toContain('**Assessment:**')
+    expect(p).toContain('RECOMMENDATIONS_JSON:')
+    expect(p).toContain('END_RECOMMENDATIONS_JSON')
+  })
+
+  it('keeps the authoritative fact sheet and profile identity', () => {
+    const p = buildAnalyzeLlmPrompt({ ...base, compact: true })
+    expect(p).toContain('Shot Facts')
+    expect(p).toContain('Test')
+  })
+
+  it('serialises profile JSON without pretty-printing (no indented newlines)', () => {
+    const p = buildAnalyzeLlmPrompt({ ...base, compact: true })
+    // Compact JSON contains the keys inline, not on their own indented lines.
+    expect(p).toContain('"key":"var_0"')
+  })
+
+  it('still includes taste context when provided', () => {
+    const p = buildAnalyzeLlmPrompt({
+      ...base, compact: true, tasteContext: '## Taste Goal\nLess sour.',
+    })
+    expect(p).toContain('Taste Goal')
+  })
+})

--- a/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
+++ b/apps/web/src/services/interceptor/analyzeLlmPrompt.ts
@@ -11,9 +11,29 @@ export interface AnalyzeLlmPromptInput {
   cleanStages: unknown[]
   facts: ShotFacts
   tasteContext: string
+  /**
+   * Build a compacted prompt that fits a small (~4096-token) context window,
+   * for on-device providers (Apple Intelligence / Gemma). Drops the large
+   * profiling/analysis knowledge blocks and the worked example, and serialises
+   * the profile JSON without pretty-printing, while preserving the exact output
+   * contract (5 numbered sections + RECOMMENDATIONS_JSON) that the parser needs.
+   */
+  compact?: boolean
 }
 
+/**
+ * Condensed analysis framework used in compact mode. Keeps only the rules that
+ * prevent the most common on-device mistakes (misreading a Targeted exit as a
+ * failure, inventing values) — the full framework lives in ANALYSIS_KNOWLEDGE.
+ */
+const COMPACT_ANALYSIS_KNOWLEDGE = `Rules:
+- A stage ends when an exit trigger fires. A Targeted exit (weight/time/pressure/flow reached, or a stage with no triggers finishing on its planned dynamics or the global weight target) is CORRECT — never call it "early termination". A Failsafe exit means a backstop fired before the intended target.
+- Stall = a timed stage that gained < 0.5 g (puck choked → coarser grind). Channeling = pressure falls while flow rises (uneven puck → fix distribution, not the profile).
+- Sour = under-extraction (grind finer / raise temp); bitter = over-extraction (grind coarser / lower temp).
+- Only state facts supported by the data below. Do NOT invent pressures, temperatures, weights, or events. Prefer one or two specific, numeric recommendations.`
+
 export function buildAnalyzeLlmPrompt(input: AnalyzeLlmPromptInput): string {
+  if (input.compact) return buildCompactAnalyzeLlmPrompt(input)
   const {
     profileName, temperature, targetWeight, profileDescription,
     profileVars, cleanStages, facts, tasteContext,
@@ -137,5 +157,94 @@ Rules for recommendations:
 - For stage-specific changes, use the stage name from Profile Stages
 - confidence: "high" = strong evidence from data, "medium" = likely beneficial, "low" = worth trying
 - If no recommendations apply, output an empty array: RECOMMENDATIONS_JSON:\n[]\nEND_RECOMMENDATIONS_JSON
+`
+}
+
+/**
+ * Compact analysis prompt for on-device models with a ~4096-token window.
+ * Preserves the exact output contract (5 numbered sections + RECOMMENDATIONS_JSON)
+ * so the existing parser/validator keep working, but drops the large knowledge
+ * blocks and worked example and serialises profile JSON without indentation.
+ */
+function buildCompactAnalyzeLlmPrompt(input: AnalyzeLlmPromptInput): string {
+  const {
+    profileName, temperature, targetWeight, profileDescription,
+    profileVars, cleanStages, facts, tasteContext,
+  } = input
+  return `You are an expert espresso barista analyzing a shot from a Meticulous Espresso Machine.
+
+## Analysis Rules
+${COMPACT_ANALYSIS_KNOWLEDGE}
+
+## Profile
+Name: ${profileName}; Temperature: ${temperature ?? 'Not set'}°C; Target Weight: ${targetWeight ?? 'Not set'}g
+${profileDescription ? `Description: ${profileDescription}` : ''}
+Variables: ${JSON.stringify(profileVars)}
+Stages: ${JSON.stringify(cleanStages)}
+
+## Shot Facts (authoritative — trust over any assumption)
+${buildFactSheet(facts)}
+${tasteContext ? `\n${tasteContext}\n` : ''}
+---
+
+Provide a detailed expert analysis. Use EXACTLY these 5 section headers (## then number, period, space, title) with the bold subsection headers shown, and make ALL content bullet points starting with "- " (1-2 sentences each). Do NOT add extra sections.
+
+## 1. Shot Performance
+
+**What Happened:**
+- [Stage-by-stage description, notable events, final weight vs target]
+
+**Assessment:** [Exactly one: Good / Acceptable / Needs Improvement / Problematic]
+
+## 2. Root Cause Analysis
+
+**Primary Factors:**
+- [Most likely cause]
+
+**Secondary Considerations:**
+- [Other contributing factors]
+
+## 3. Setup Recommendations
+
+**Priority Changes:**
+- [Most important change — specific with numbers]
+
+**Additional Suggestions:**
+- [Other tweaks]
+
+## 4. Profile Recommendations
+
+**Recommended Adjustments:**
+- [Specific profile changes: timing, triggers, targets]
+
+**Reasoning:**
+- [Why these changes help]
+
+## 5. Profile Design Observations
+
+**Strengths:**
+- [Well-designed aspects]
+
+**Potential Improvements:**
+- [Exit trigger or safety limit suggestions]
+
+## Structured Recommendations (MANDATORY)
+
+After the sections, output a structured JSON block. Use EXACTLY this format — the markers are parsed programmatically:
+
+RECOMMENDATIONS_JSON:
+[
+  {
+    "variable": "<variable key copied verbatim from a Variables entry above, e.g. 'pressure_Max Pressure' — never invent names like 'pressure_2'>",
+    "current_value": <current numeric value>,
+    "recommended_value": <suggested numeric value>,
+    "stage": "<stage name, or 'global' for top-level settings>",
+    "confidence": "<high|medium|low>",
+    "reason": "<one-sentence explanation>"
+  }
+]
+END_RECOMMENDATIONS_JSON
+
+Only include recommendations with a SPECIFIC numeric change. If none apply, output an empty array: RECOMMENDATIONS_JSON:\n[]\nEND_RECOMMENDATIONS_JSON
 `
 }


### PR DESCRIPTION
## Problem
On iOS 26/27, users running **Apple Intelligence** (on-device) hit:
- **"exceeded model context window size"** when generating shot analysis
- a generic error when generating a profile

## Root cause
Apple Intelligence's Foundation Model runs in a fixed **~4096-token** window shared between input and output. The capgo plugin calls `streamResponse(to:)` with **no** `GenerationOptions`, so `maxTokens` is ignored for Apple Intelligence — the only lever is prompt size. The full prompts overflow the window:
- shot analysis (`buildAnalyzeLlmPrompt`): **~3700 tokens** (profiling + analysis knowledge, full profile JSON pretty-printed, a worked example)
- profile generation (`buildFullProfilePrompt`): **~2440 tokens** (plus a large JSON output)

## Fix
- Add `contextWindowTokens` to `ProviderCapabilities` (4096 on the local provider) and a `needsCompactPrompt()` helper.
- Build **compact prompt variants** for small-context (on-device) providers, wired at the two native call sites (`DirectModeInterceptor` analyze + `BrowserAIService.generateProfile`):
  - **Analysis:** drops heavy knowledge blocks + worked example, serialises profile JSON without pretty-printing, **keeps the exact 5-section + `RECOMMENDATIONS_JSON` output contract**. ~3700 -> **~1400 tokens**.
  - **Profile:** condensed guidelines/validation/OEPF reference, keeps the `**Profile Created:**` + json fence contract. ~2440 -> **~630 tokens**.
- Hosted providers (Gemini/OpenAI-compatible) are **unchanged**.

Native-only fix — Apple Intelligence does not exist in the Python server runtime, so no server parity change is required.

## Tests
- New: compact builders are materially smaller, fit the window, and retain every required structural marker; `needsCompactPrompt` + capability tests.
- Full suite: **1387 passing**, lint clean, build green.
