### PR TITLE
feat(android): support the hardware back button (#536)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -75,6 +75,9 @@ import { useStorageMigration } from '@/services/storage'
 import { useNetworkStatus } from '@/hooks/useNetworkStatus'
 import { useBrewNotifications } from '@/hooks/useBrewNotifications'
 import { useSoundEffects, useGlobalSoundDelegation } from '@/hooks/useSoundEffects'
+import { useAndroidBackButton } from '@/hooks/useAndroidBackButton'
+import { closeTopmostOverlay } from '@/lib/backNavigation'
+import { hasUnsavedChanges } from '@/lib/unsavedChanges'
 
 function App() {
   const { t } = useTranslation()
@@ -863,24 +866,23 @@ function App() {
     setViewState('start')
   }, [refreshProfileCount])
 
-  // Swipe navigation for mobile - back navigation via swipe right
-  const handleSwipeRight = useCallback(() => {
-    if (!isMobile) return
-    
-    // Handle back navigation based on current view
+  // Shared back-navigation mapping used by both the mobile swipe gesture and
+  // the Android hardware back button. Returns true if it navigated, false if
+  // there was nowhere to go back to (e.g. the main screen).
+  const navigateBack = useCallback((): boolean => {
     switch (viewState) {
       case 'form':
         handleBackToStart()
-        break
+        return true
       case 'results':
         handleReset()
-        break
+        return true
       case 'history-detail':
         setViewState('profile-catalogue')
-        break
+        return true
       case 'profile-catalogue':
         handleBackToStart()
-        break
+        return true
       case 'settings':
       case 'pour-over':
       case 'live-shot':
@@ -888,7 +890,7 @@ function App() {
       case 'dial-in':
       case 'machine-status':
         handleBackToStart()
-        break
+        return true
       case 'shot-history': {
         const prev = previousViewStateRef.current
         if (prev === 'shot-analysis' || prev === 'history-detail') {
@@ -896,19 +898,40 @@ function App() {
         } else {
           handleBackToStart()
         }
-        break
+        return true
       }
-      // Don't navigate on start, loading, or error views - but still block browser gesture
+      // start, loading, onboarding, error: nowhere to go back to.
       default:
-        break
+        return false
     }
-  }, [isMobile, viewState, handleBackToStart, handleReset, setViewState])
+  }, [viewState, handleBackToStart, handleReset, setViewState])
+
+  // Swipe navigation for mobile - back navigation via swipe right
+  const handleSwipeRight = useCallback(() => {
+    if (!isMobile) return
+    navigateBack()
+  }, [isMobile, navigateBack])
 
   useSwipeNavigation({
     onSwipeRight: handleSwipeRight,
     // Keep enabled on mobile to always block browser's native back gesture
     enabled: isMobile,
   })
+
+  // Android hardware back button. Priority: close an open modal/dialog/menu,
+  // otherwise confirm before discarding unsaved edits and navigate to the
+  // previous view. On the main screen there is nowhere to go back to, so the
+  // press is intentionally a no-op (the app is not exited).
+  const handleAndroidBack = useCallback(() => {
+    if (closeTopmostOverlay()) return
+    if (qrDialogOpen) { setQrDialogOpen(false); return }
+    if (showAddProfileDialog) { setShowAddProfileDialog(false); return }
+    if (pendingImportUrl) { setPendingImportUrl(null); return }
+    if (hasUnsavedChanges() && !window.confirm(t('profileEdit.unsavedChanges'))) return
+    navigateBack()
+  }, [qrDialogOpen, showAddProfileDialog, pendingImportUrl, navigateBack, t])
+
+  useAndroidBackButton(handleAndroidBack)
 
   const handleViewHistoryEntry = (entry: HistoryEntry, cachedImageUrl?: string) => {
     document.getElementById('root')?.scrollTo(0, 0)

--- a/apps/web/src/components/HistoryView.tsx
+++ b/apps/web/src/components/HistoryView.tsx
@@ -49,6 +49,7 @@ import { getServerUrl } from '@/lib/config'
 import { invalidateCatalogueCache } from '@/lib/catalogueCache'
 import { isDirectMode, isNativePlatform } from '@/lib/machineMode'
 import { hasFeature } from '@/lib/featureFlags'
+import { useUnsavedChangesGuard } from '@/lib/unsavedChanges'
 import { getProfileImageValue, resolveDisplayImage } from '@/hooks/useProfileImageSrc'
 import { profileService } from '@/services/profileService'
 
@@ -714,6 +715,9 @@ export function ProfileDetailView({ entry, onBack, onRunProfile, onEntryUpdated,
     window.addEventListener('beforeunload', handler)
     return () => window.removeEventListener('beforeunload', handler)
   }, [hasEditChanges])
+
+  // Guard in-app navigation (e.g. Android hardware back) against losing edits.
+  useUnsavedChangesGuard(hasEditChanges)
 
   const handleStartEdit = (section: 'title' | 'details') => {
     const pj = entry.profile_json as ProfileData | null

--- a/apps/web/src/hooks/useAndroidBackButton.test.ts
+++ b/apps/web/src/hooks/useAndroidBackButton.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+let mockIsNative = false
+let mockPlatform = 'web'
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: () => mockIsNative,
+    getPlatform: () => mockPlatform,
+  },
+}))
+
+const mockRemove = vi.fn()
+const mockAddListener = vi.fn(async () => ({ remove: mockRemove }))
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: (...args: unknown[]) => mockAddListener(...args),
+  },
+}))
+
+import { useAndroidBackButton } from './useAndroidBackButton'
+
+describe('useAndroidBackButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsNative = false
+    mockPlatform = 'web'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not register on the web', () => {
+    renderHook(() => useAndroidBackButton(() => {}))
+    expect(mockAddListener).not.toHaveBeenCalled()
+  })
+
+  it('does not register on native iOS', () => {
+    mockIsNative = true
+    mockPlatform = 'ios'
+    renderHook(() => useAndroidBackButton(() => {}))
+    expect(mockAddListener).not.toHaveBeenCalled()
+  })
+
+  it('registers a backButton listener on native Android', async () => {
+    mockIsNative = true
+    mockPlatform = 'android'
+    const handler = vi.fn()
+    await act(async () => {
+      renderHook(() => useAndroidBackButton(handler))
+    })
+    expect(mockAddListener).toHaveBeenCalledWith('backButton', expect.any(Function))
+
+    // Simulate the hardware back press.
+    const registered = mockAddListener.mock.calls[0][1] as () => void
+    registered()
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not register when disabled', () => {
+    mockIsNative = true
+    mockPlatform = 'android'
+    renderHook(() => useAndroidBackButton(() => {}, false))
+    expect(mockAddListener).not.toHaveBeenCalled()
+  })
+
+  it('removes the listener on unmount', async () => {
+    mockIsNative = true
+    mockPlatform = 'android'
+    let unmountFn: () => void = () => {}
+    await act(async () => {
+      const { unmount } = renderHook(() => useAndroidBackButton(() => {}))
+      unmountFn = unmount
+    })
+    await act(async () => {
+      unmountFn()
+    })
+    expect(mockRemove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/hooks/useAndroidBackButton.ts
+++ b/apps/web/src/hooks/useAndroidBackButton.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react'
+import { Capacitor } from '@capacitor/core'
+
+/**
+ * Registers an Android hardware "back" button handler via the Capacitor App
+ * plugin.
+ *
+ * Registering a `backButton` listener overrides Capacitor's default behaviour
+ * (which would exit the app on the root history entry), so the supplied handler
+ * has full control: it decides whether to close a modal, navigate to a previous
+ * view, or do nothing. The listener is only attached on native Android; on iOS
+ * and the web it is a no-op.
+ *
+ * The handler is stored in a ref so the listener does not need to be torn down
+ * and re-registered on every render when an inline callback is passed.
+ */
+export function useAndroidBackButton(handler: () => void, enabled = true): void {
+  const handlerRef = useRef(handler)
+  useEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
+
+  useEffect(() => {
+    if (!enabled) return
+    if (!Capacitor.isNativePlatform() || Capacitor.getPlatform() !== 'android') return
+
+    let cancelled = false
+    let remove: (() => void) | undefined
+
+    // Return the module namespace (not the plugin proxy) from the async import,
+    // then access App on it: awaiting a plugin proxy directly triggers
+    // "App.then() is not implemented" on Android.
+    void (async () => {
+      const mod = await import('@capacitor/app')
+      if (cancelled) return
+      const listener = await mod.App.addListener('backButton', () => {
+        handlerRef.current()
+      })
+      if (cancelled) {
+        listener.remove()
+        return
+      }
+      remove = () => listener.remove()
+    })()
+
+    return () => {
+      cancelled = true
+      remove?.()
+    }
+  }, [enabled])
+}

--- a/apps/web/src/lib/backNavigation.test.ts
+++ b/apps/web/src/lib/backNavigation.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { closeTopmostOverlay } from './backNavigation'
+
+function addOverlay(role: string): HTMLElement {
+  const el = document.createElement('div')
+  el.setAttribute('role', role)
+  el.setAttribute('data-state', 'open')
+  document.body.appendChild(el)
+  return el
+}
+
+describe('closeTopmostOverlay', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('returns false when no overlay is open', () => {
+    expect(closeTopmostOverlay()).toBe(false)
+  })
+
+  it('ignores overlays that are not open', () => {
+    const el = document.createElement('div')
+    el.setAttribute('role', 'dialog')
+    el.setAttribute('data-state', 'closed')
+    document.body.appendChild(el)
+    expect(closeTopmostOverlay()).toBe(false)
+  })
+
+  it.each(['dialog', 'alertdialog', 'menu', 'listbox'])(
+    'detects an open %s and dispatches an Escape keydown',
+    (role) => {
+      addOverlay(role)
+      const events: string[] = []
+      const listener = (e: KeyboardEvent) => events.push(e.key)
+      document.addEventListener('keydown', listener)
+
+      expect(closeTopmostOverlay()).toBe(true)
+      expect(events).toEqual(['Escape'])
+
+      document.removeEventListener('keydown', listener)
+    },
+  )
+
+  it('dispatches a cancelable, bubbling Escape event', () => {
+    addOverlay('dialog')
+    let captured: KeyboardEvent | undefined
+    const listener = (e: KeyboardEvent) => { captured = e }
+    document.addEventListener('keydown', listener)
+
+    closeTopmostOverlay()
+
+    expect(captured?.key).toBe('Escape')
+    expect(captured?.bubbles).toBe(true)
+    expect(captured?.cancelable).toBe(true)
+
+    document.removeEventListener('keydown', listener)
+  })
+})

--- a/apps/web/src/lib/backNavigation.ts
+++ b/apps/web/src/lib/backNavigation.ts
@@ -1,0 +1,38 @@
+/**
+ * Detects and dismisses the topmost open Radix overlay (dialog, alert dialog,
+ * sheet, dropdown/select/context menu, or listbox popover).
+ *
+ * Radix closes the topmost dismissable layer in response to an Escape keydown
+ * on `document`. Android's hardware back button does not emit a keyboard event,
+ * so we synthesise one. This lets a single back press close whatever modal is
+ * currently open, mirroring the platform's expected behaviour, without wiring
+ * every component's open state up to the app root.
+ *
+ * @returns true if an open overlay was found and an Escape was dispatched to
+ *   close it (i.e. the back press was consumed), false otherwise.
+ */
+const OPEN_OVERLAY_SELECTOR = [
+  '[role="dialog"][data-state="open"]',
+  '[role="alertdialog"][data-state="open"]',
+  '[role="menu"][data-state="open"]',
+  '[role="listbox"][data-state="open"]',
+  '[data-radix-popper-content-wrapper] [data-state="open"]',
+].join(',')
+
+export function closeTopmostOverlay(): boolean {
+  if (typeof document === 'undefined') return false
+  const openOverlay = document.querySelector(OPEN_OVERLAY_SELECTOR)
+  if (!openOverlay) return false
+
+  document.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: 'Escape',
+      code: 'Escape',
+      keyCode: 27,
+      which: 27,
+      bubbles: true,
+      cancelable: true,
+    }),
+  )
+  return true
+}

--- a/apps/web/src/lib/unsavedChanges.test.ts
+++ b/apps/web/src/lib/unsavedChanges.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import {
+  registerUnsavedChangesGuard,
+  hasUnsavedChanges,
+  useUnsavedChangesGuard,
+} from './unsavedChanges'
+
+describe('unsavedChanges registry', () => {
+  it('reports no unsaved changes when nothing is registered', () => {
+    expect(hasUnsavedChanges()).toBe(false)
+  })
+
+  it('reports unsaved changes while a truthy predicate is registered', () => {
+    const unregister = registerUnsavedChangesGuard(() => true)
+    expect(hasUnsavedChanges()).toBe(true)
+    unregister()
+    expect(hasUnsavedChanges()).toBe(false)
+  })
+
+  it('ignores predicates that report no changes', () => {
+    const unregister = registerUnsavedChangesGuard(() => false)
+    expect(hasUnsavedChanges()).toBe(false)
+    unregister()
+  })
+
+  it('returns true if any registered predicate reports changes', () => {
+    const a = registerUnsavedChangesGuard(() => false)
+    const b = registerUnsavedChangesGuard(() => true)
+    expect(hasUnsavedChanges()).toBe(true)
+    a()
+    b()
+    expect(hasUnsavedChanges()).toBe(false)
+  })
+})
+
+describe('useUnsavedChangesGuard', () => {
+  it('reflects the latest hasChanges value without re-registering', () => {
+    const { rerender, unmount } = renderHook(({ dirty }) => useUnsavedChangesGuard(dirty), {
+      initialProps: { dirty: false },
+    })
+    expect(hasUnsavedChanges()).toBe(false)
+
+    rerender({ dirty: true })
+    expect(hasUnsavedChanges()).toBe(true)
+
+    rerender({ dirty: false })
+    expect(hasUnsavedChanges()).toBe(false)
+
+    rerender({ dirty: true })
+    expect(hasUnsavedChanges()).toBe(true)
+
+    unmount()
+    expect(hasUnsavedChanges()).toBe(false)
+  })
+})

--- a/apps/web/src/lib/unsavedChanges.ts
+++ b/apps/web/src/lib/unsavedChanges.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Lightweight global registry of "unsaved changes" predicates.
+ *
+ * Views that hold edits which require an explicit save register a predicate
+ * here. The Android hardware back handler (and any other global navigation
+ * guard) can then ask whether leaving the current screen would discard work,
+ * without every editable component having to thread its dirty state up to the
+ * app root.
+ */
+const guards = new Set<() => boolean>()
+
+export function registerUnsavedChangesGuard(predicate: () => boolean): () => void {
+  guards.add(predicate)
+  return () => {
+    guards.delete(predicate)
+  }
+}
+
+export function hasUnsavedChanges(): boolean {
+  for (const predicate of guards) {
+    if (predicate()) return true
+  }
+  return false
+}
+
+/**
+ * Register the current component's unsaved-changes state for the lifetime of
+ * the component. `hasChanges` is read live via a ref, so the predicate always
+ * reflects the latest render without re-registering on every change.
+ */
+export function useUnsavedChangesGuard(hasChanges: boolean): void {
+  const ref = useRef(hasChanges)
+  useEffect(() => {
+    ref.current = hasChanges
+  }, [hasChanges])
+  useEffect(() => registerUnsavedChangesGuard(() => ref.current), [])
+}


### PR DESCRIPTION
Closes #536.

## What
Adds Android hardware **back button** support. Registering a Capacitor `App` `backButton` listener overrides Capacitor's default (exit-on-root) so the app fully controls the behaviour.

Priority order on each back press:
1. **Close the topmost open modal** — dialog, sheet, dropdown/select menu, or popover. The hardware back button emits no keyboard event, so we synthesise an `Escape` keydown, which closes the topmost Radix dismissable layer (also covers the app-level QR, add-profile and import dialogs).
2. **Guard unsaved edits** — if the current view has unsaved changes, confirm before discarding (reuses the existing `profileEdit.unsavedChanges` prompt).
3. **Navigate to the previous view** (breadcrumb), mirroring the existing mobile swipe-right map.
4. **Main screen: do nothing** — there is nowhere to go back to, so the press is a no-op and the app is not exited (as requested in the issue).

## How
- New `useAndroidBackButton` hook — registers the listener on native **Android only** (no-op on iOS/web); returns the module namespace from the dynamic import (avoids the Capacitor plugin-proxy "thenable" pitfall).
- New `closeTopmostOverlay()` — detects open Radix overlays by role + `data-state="open"` and dispatches Escape.
- New `useUnsavedChangesGuard` — a small global registry so editable views opt into the guard without threading dirty state up to `App.tsx`. The profile detail editor is the first consumer.
- The view back-navigation `switch` is extracted from the swipe handler into a shared `navigateBack()` used by both swipe and hardware back.

Native-only change; no server/Python parity required. `@capacitor/app` is already a dependency and registered in the Android project.

## Tests
- `unsavedChanges` registry + hook, `closeTopmostOverlay` overlay detection/dispatch, and `useAndroidBackButton` platform gating / register / fire / cleanup. **17 new tests.**
- Full suite **1386 passing**, lint clean (0 errors), build green.

No new locale strings (reuses `profileEdit.unsavedChanges`, present in all 6 locales).
